### PR TITLE
Small fixes

### DIFF
--- a/source/dsl/instruction_parsers/TrainMLModelParser.py
+++ b/source/dsl/instruction_parsers/TrainMLModelParser.py
@@ -28,8 +28,13 @@ class TrainMLModelParser:
 
         valid_keys = ["assessment", "selection", "dataset", "strategy", "labels", "metrics", "settings", "batch_size", "type", "reports",
                       "optimization_metric", 'refit_optimal_model']
+        ParameterValidator.assert_type_and_value(instruction['settings'], list, TrainMLModelParser.__name__, 'settings')
         ParameterValidator.assert_keys(list(instruction.keys()), valid_keys, TrainMLModelParser.__name__, "TrainMLModel")
         ParameterValidator.assert_type_and_value(instruction['refit_optimal_model'], bool, TrainMLModelParser.__name__, 'refit_optimal_model')
+        ParameterValidator.assert_type_and_value(instruction['metrics'], list, TrainMLModelParser.__name__, 'metrics')
+        ParameterValidator.assert_type_and_value(instruction['optimization_metric'], str, TrainMLModelParser.__name__, 'optimization_metric')
+        ParameterValidator.assert_type_and_value(instruction['batch_size'], int, TrainMLModelParser.__name__, 'batch_size')
+        ParameterValidator.assert_type_and_value(instruction['strategy'], str, TrainMLModelParser.__name__, 'strategy')
 
         settings = self._parse_settings(instruction, symbol_table)
         dataset = symbol_table.get(instruction["dataset"])

--- a/source/reports/ml_reports/MotifSeedRecovery.py
+++ b/source/reports/ml_reports/MotifSeedRecovery.py
@@ -7,6 +7,8 @@ import numpy as np
 from source.data_model.dataset.Dataset import Dataset
 from source.ml_methods.MLMethod import MLMethod
 from source.ml_methods.RandomForestClassifier import RandomForestClassifier
+from source.ml_methods.SVM import SVM
+from source.ml_methods.SimpleLogisticRegression import SimpleLogisticRegression
 from source.reports.ReportOutput import ReportOutput
 from source.reports.ReportResult import ReportResult
 from source.reports.ml_reports.MLReport import MLReport
@@ -242,6 +244,11 @@ class MotifSeedRecovery(MLReport):
         location = "MotifSeedRecovery"
 
         run_report = True
+
+        if not any([isinstance(self.method, legal_method) for legal_method in (RandomForestClassifier, SimpleLogisticRegression, SVM)]):
+            logging.warning(f"{location} report can only be created for RandomForestClassifier, SimpleLogisticRegression or SVM, but got "
+                            f"{type(self.method).__name__} instead. {location} report will not be created.")
+            run_report = False
 
         if self.label not in self.implanted_motifs_per_label.keys():
             warnings.warn(

--- a/source/workflows/instructions/MLProcess.py
+++ b/source/workflows/instructions/MLProcess.py
@@ -61,7 +61,7 @@ class MLProcess:
 
     def run(self, split_index: int) -> HPItem:
 
-        print(f"{datetime.datetime.now()}: Evaluating hyperparameter setting: {self.hp_setting}...\n", flush=True)
+        print(f"{datetime.datetime.now()}: Evaluating hyperparameter setting: {self.hp_setting}...", flush=True)
 
         PathBuilder.build(self.path)
         self._set_paths()


### PR DESCRIPTION
- Bugfix MotifSeedRecovery: extra check in check\_prerequisites
- remove newline from 'evaluating hyperparameter setting' print statement so every HP setting evaluation ends up nicely in one block in the printed results
- extra ParameterValidator checks for TrainMLModel instruction (should make it easier for the user to detect when they misunderstand what should be filled in, especially string/list values)
