### PR TITLE
Updated docs 'How to make an immuneML dataset in Galaxy'

### DIFF
--- a/docs/source/galaxy/how_to_make_an_immuneML_dataset_in_galaxy.rst
+++ b/docs/source/galaxy/how_to_make_an_immuneML_dataset_in_galaxy.rst
@@ -1,12 +1,94 @@
 How to make an immuneML dataset in Galaxy
 =========================================
 
+The ‘Create dataset’ Galaxy tool allows users to import data from various formats and create immuneML datasets in Galaxy.
+The imported files are stored as a Galaxy collection, which will appear as a history item on the right side of the screen.
+Such Galaxy collections can later be selected as input to other tools.
+
+The tool can be used to create Repertoire-, Sequence- or ReceptorDatasets. RepertoireDatasets should be used when making
+predictions per repertoire, such as predicting a disease state. SequenceDatasets or ReceptorDatasets should be used when
+predicting values for unpaired (single-chain) and paired immune receptors respectively, like antigen specificity.
+
+The ‘Create dataset’ tool has a simple and an advanced interface. The simple interface is fully button-based, and relies
+on default settings for importing datasets. The advanced interface gives full control over import settings through a YAML
+specification. In most cases, using the simple interface will suffice.
+
+Using the simple interface
+--------------------------
+
+
+
+
+Using the advanced interface
+----------------------------
+
+
+The advanced interface has two input fields:
+
+1. A YAMl specification,
+
+2. A list of data and metadata files to import
+
+
+The YAML specification describes how the dataset should be created from the supplied files. See :ref:`YAML specification`
+for more details on writing a YAML specification file. For this tool, one dataset :ref:`Datasets` must be specified under definitions, and
+the :ref:`DatasetGeneration` instruction must be used.
+
+The `path` parameter for the dataset must always be set to the current working directory (`./`), and the DatasetGeneration
+instruction can here only be used with one dataset and one export format. Otherwise, the specification is written the same
+as when running immuneML locally.
+
+A complete YAML specification could look like this:
+
+.. indent with spaces
+.. code-block:: yaml
+
+    definitions:
+      datasets:
+        my_dataset: # user-defined dataset name
+          format: VDJdb
+          params:
+            is_repertoire: True
+            metadata_file: metadata.csv # the metadata file is identified by name
+            path: ./ # the path must always be the current working directory
+            # other import parameters may be specified here
+    instructions:
+      my_dataset_generation_instruction: # user-defined instruction name
+          type: DatasetGeneration # which instruction to execute
+          datasets: # only one dataset can be given here
+              - my_dataset
+          export_formats:
+          # only one format can be specified here and the dataset in this format will be
+          # available as a Galaxy collection afterwards
+              - AIRR
+
+
+Metadata file field is used when creating a dataset consisting of immune repertoires
+and describes the metadata information for one repertoire per row. For the format of
+the metadata file, see :ref:`What should the metadata file look like?`. For datasets consisting of immune receptor or receptor
+sequences, the metadata information is provided directly in the files including receptors
+as separate fields (e.g. epitope field in VDJdb format).
+
+The third field includes all data files. For repertoire datasets, a repertoire file
+corresponding to each metadata row will be imported (if a repertoire was specified in
+the metadata but the corresponding repertoire file is not present, the tool will raise
+an error). For receptor or receptor sequence datasets, metadata file is not used, but
+instead all data from the corresponding format is imported along with its metadata.
+
+
+
+
+For this tool we need to specify a dataset under definitions, and
+
+
+
+
 immuneML dataset tool allows users to create an immuneML dataset in Galaxy.
 From immune repertoire files in MiXCR, Adaptive Biotechnologies or AIRR format or
 receptor files as extracted from VDJdb, a Galaxy collection (a list of immuneML-imported
 files) is created and can be used as input for the immuneML wrapper tool.
 
-The tool has three input fields:
+The advanced interface has three input fields:
 
 1. YAML specification,
 

--- a/docs/source/galaxy/how_to_make_an_immuneML_dataset_in_galaxy.rst
+++ b/docs/source/galaxy/how_to_make_an_immuneML_dataset_in_galaxy.rst
@@ -2,132 +2,139 @@ How to make an immuneML dataset in Galaxy
 =========================================
 
 The ‘Create dataset’ Galaxy tool allows users to import data from various formats and create immuneML datasets in Galaxy.
-The imported files are stored as a Galaxy collection, which will appear as a history item on the right side of the screen.
+The imported files are stored in a Galaxy collection, which will appear as a history item on the right side of the screen.
 Such Galaxy collections can later be selected as input to other tools.
 
-The tool can be used to create Repertoire-, Sequence- or ReceptorDatasets. RepertoireDatasets should be used when making
+The tool has a simple and an advanced interface. The simple interface is fully button-based, and relies
+on default settings for importing datasets. The advanced interface gives full control over import settings through a YAML
+specification. In most cases, the simple interface will suffice.
+
+
+immuneML datasets
+-----------------
+The three types of datasets used in immuneML are Repertoire-, Sequence- or ReceptorDatasets. RepertoireDatasets should be used when making
 predictions per repertoire, such as predicting a disease state. SequenceDatasets or ReceptorDatasets should be used when
 predicting values for unpaired (single-chain) and paired immune receptors respectively, like antigen specificity.
 
-The ‘Create dataset’ tool has a simple and an advanced interface. The simple interface is fully button-based, and relies
-on default settings for importing datasets. The advanced interface gives full control over import settings through a YAML
-specification. In most cases, using the simple interface will suffice.
-
-Using the simple interface
---------------------------
-
-
-
-
-Using the advanced interface
-----------------------------
+In order to use a dataset for training ML classifiers, the metadata, which contains prediction labels, needs to be available.
+For RepertoireDatasets, the metadata is supplied through a metadata file. The metadata file is a .csv file which contains
+one repertoire (filename) per row, and the metadata labels for that repertoire. For more details on structuring the metadata file, see
+:ref:`What should the metadata file look like?`. Note that only the Repertoire files that are present in the metadata file
+will be imported.
+For Sequence- and ReceptorDatasets the metadata should be available in the columns of the sequence data files. For example,
+VDJdb files contain columns named 'Epitope', 'Epitope gene' and 'Epitope species'. These columns can be specified to serve
+as metadata columns.
 
 
-The advanced interface has two input fields:
+Using the simple 'Create dataset' interface
+-------------------------------------------
 
-1. A YAMl specification,
+In the simple interface the user has to select an input file format, dataset type and a list of data files to use.
+For RepertoireDatasets, a metadata file must be selected from the history, whereas for Sequence- and ReceptorDatasets
+the names of the columns containing metadata must be specified. The names of the metadata columns are in later
+analyses available as labels for the Sequence- and ReceptorDatasets.
 
-2. A list of data and metadata files to import
 
+Using the advanced 'Create dataset' interface
+---------------------------------------------
+
+When using the advanced interface of the 'Create dataset' tool, a YAML specification and a list of files must be filled in.
+The list of selected files should contain all data files to be imported, and additionally in the
+case of a RepertoireDataset a metadata file.
 
 The YAML specification describes how the dataset should be created from the supplied files. See :ref:`YAML specification`
-for more details on writing a YAML specification file. For this tool, one dataset :ref:`Datasets` must be specified under definitions, and
-the :ref:`DatasetGeneration` instruction must be used.
+for more details on writing a YAML specification file. For this tool, one :ref:`Dataset <Datasets>` must be specified
+under definitions, and the :ref:`DatasetGeneration` instruction must be used.
 
-The `path` parameter for the dataset must always be set to the current working directory (`./`), and the DatasetGeneration
-instruction can here only be used with one dataset and one export format. Otherwise, the specification is written the same
-as when running immuneML locally.
+The **path** parameter for the dataset must always be set to the current working directory ('./'), and the DatasetGeneration
+instruction can here only be used with one dataset (as defined under **definitions**) and one export format. Otherwise, the
+specification is written the same as when running immuneML locally.
 
-A complete YAML specification could look like this:
+A complete YAML specification for a RepertoireDataset could look like this:
 
 .. indent with spaces
 .. code-block:: yaml
 
     definitions:
       datasets:
-        my_dataset: # user-defined dataset name
+        my_repertoire_dataset: # user-defined dataset name
           format: VDJdb
           params:
-            is_repertoire: True
-            metadata_file: metadata.csv # the metadata file is identified by name
             path: ./ # the path must always be the current working directory
+            is_repertoire: True # import a RepertoireDataset
+            metadata_file: metadata.csv # the metadata file is identified by name
             # other import parameters may be specified here
     instructions:
       my_dataset_generation_instruction: # user-defined instruction name
-          type: DatasetGeneration # which instruction to execute
-          datasets: # only one dataset can be given here
-              - my_dataset
+          type: DatasetGeneration
+          datasets: # specify the dataset defined above
+              - my_repertoire_dataset
           export_formats:
           # only one format can be specified here and the dataset in this format will be
           # available as a Galaxy collection afterwards
-              - AIRR
+              - Pickle # Can be AIRR (human-readable) or Pickle (recommended)
 
-
-Metadata file field is used when creating a dataset consisting of immune repertoires
-and describes the metadata information for one repertoire per row. For the format of
-the metadata file, see :ref:`What should the metadata file look like?`. For datasets consisting of immune receptor or receptor
-sequences, the metadata information is provided directly in the files including receptors
-as separate fields (e.g. epitope field in VDJdb format).
-
-The third field includes all data files. For repertoire datasets, a repertoire file
-corresponding to each metadata row will be imported (if a repertoire was specified in
-the metadata but the corresponding repertoire file is not present, the tool will raise
-an error). For receptor or receptor sequence datasets, metadata file is not used, but
-instead all data from the corresponding format is imported along with its metadata.
-
-
-
-
-For this tool we need to specify a dataset under definitions, and
-
-
-
-
-immuneML dataset tool allows users to create an immuneML dataset in Galaxy.
-From immune repertoire files in MiXCR, Adaptive Biotechnologies or AIRR format or
-receptor files as extracted from VDJdb, a Galaxy collection (a list of immuneML-imported
-files) is created and can be used as input for the immuneML wrapper tool.
-
-The advanced interface has three input fields:
-
-1. YAML specification,
-
-2. Metadata file (optional)
-
-3. A list of files to import to a dataset.
-
-YAML specification defines how the dataset should be created from supplied files. See :ref:`YAML specification` for more details on writing a YAML
-specification file, specifically with :ref:`DatasetGeneration` instruction. For this Galaxy tool, the specification will include only one dataset
-and only one format in which it will be exported. For instance, YAML specification could be the following:
+Alternatively, for a ReceptorDataset the complete YAML specification may look like this:
 
 .. indent with spaces
 .. code-block:: yaml
 
     definitions:
       datasets:
-        my_dataset: # dataset which to use to create a Galaxy collection
-          format: AdaptiveBiotech
+        my_receptor_dataset: # user-defined dataset name
+          format: VDJdb
           params:
-            metadata_file: metadata.csv
-            path: ./
+            path: ./ # the path must always be the current working directory
+            is_repertoire: False
+            paired: True # if True, import ReceptorDataset. If False, import SequenceDataset
+            receptor_chains: TRA_TRB # choose from TRA_TRB, TRG_TRD, IGH_IGL and IGH_IGK
+            metadata_column_mapping: # VDJdb name: immuneML name
+              # import VDJdb columns Epitope, Epitope gene and Epitope species, and save them
+              # in metadata fields epitope, epitope_gene and epitope_species which can be used as labels
+              Epitope: epitope
+              Epitope gene: epitope_gene
+              Epitope species: epitope_species
+            # other import parameters may be specified here
     instructions:
       my_dataset_generation_instruction: # user-defined instruction name
-          type: DatasetGeneration # which instruction to execute
-          datasets: # only one dataset can be given here
-              - my_dataset
+          type: DatasetGeneration
+          datasets: # specify the dataset defined above
+              - my_receptor_dataset
           export_formats:
           # only one format can be specified here and the dataset in this format will be
           # available as a Galaxy collection afterwards
-              - AIRR
+              - Pickle # Can be AIRR (human-readable) or Pickle (recommended)
 
-Metadata file field is used when creating a dataset consisting of immune repertoires
-and describes the metadata information for one repertoire per row. For the format of
-the metadata file, see :ref:`What should the metadata file look like?`. For datasets consisting of immune receptor or receptor
-sequences, the metadata information is provided directly in the files including receptors
-as separate fields (e.g. epitope field in VDJdb format).
+Note that the export format specified here will determine how dataset import should be defined in the subsequent
+YAML specifications for other immuneML Galaxy tools ('Run immuneML with YAML specification' and 'Simulate events in an immune
+dataset'). The recommended format is Pickle, as it is easiest to specify dataset import from Pickle format.
+If Pickle is chosen as the export format, the dataset definition for subsequent analyses will look like this:
 
-The third field includes all data files. For repertoire datasets, a repertoire file
-corresponding to each metadata row will be imported (if a repertoire was specified in
-the metadata but the corresponding repertoire file is not present, the tool will raise
-an error). For receptor or receptor sequence datasets, metadata file is not used, but
-instead all data from the corresponding format is imported along with its metadata.
+.. indent with spaces
+.. code-block:: yaml
+
+    definitions:
+      datasets:
+        my_analysis_dataset: # user-defined dataset name
+          format: Pickle
+          params:
+            # note that my_dataset is the name given earlier in the 'Create dataset' YAML
+            path: my_dataset.iml_dataset
+
+Alternatively, AIRR format may be specified as it is human-readable. When AIRR format is used, all relevant import
+parameters need to be specified in subsequent analyses:
+
+.. indent with spaces
+.. code-block:: yaml
+
+    definitions:
+      datasets:
+        my_analysis_dataset: # user-defined dataset name
+          format: AIRR
+          params:
+            path: ./
+            # the same value for is_repertoire and metadata_file must be used as in the first YAML
+            is_repertoire: True
+            metadata_file: metadata.csv
+            # other import parameters may be specified here
+


### PR DESCRIPTION
Updated the docs based on the new Create dataset interface (simple/advanced) and refactored sequence import

The docs now start with a little introduction about galaxy collections and immuneML datasets, and then explains both the simple and advanced interface
For the advanced interface I added an example of how to import a ReceptorDataset as well