### PR TITLE
small fixes related to galaxy interfaces

### DIFF
--- a/source/api/galaxy/build_dataset_yaml.py
+++ b/source/api/galaxy/build_dataset_yaml.py
@@ -7,6 +7,14 @@ from source.data_model.receptor.RegionType import RegionType
 from source.util.PathBuilder import PathBuilder
 
 
+def build_metadata_column_mapping(columns_str):
+    colnames = columns_str.split(",")
+    colnames = [label.strip().strip("'\"") for label in colnames]
+
+    return {colname: colname for colname in colnames if colname != ""}
+
+
+
 def build_specs(args):
     specs = {
         "definitions": {
@@ -38,6 +46,8 @@ def build_specs(args):
         specs["definitions"]["datasets"][args.dataset_name]["params"]["paired"] = paired
         if paired:
             specs["definitions"]["datasets"][args.dataset_name]["params"]["receptor_chains"] = args.receptor_chains
+
+        specs["definitions"]["datasets"][args.dataset_name]["params"]["metadata_column_mapping"] = build_metadata_column_mapping(args.metadata_columns)
     else:
         specs["definitions"]["datasets"][args.dataset_name]["params"]["is_repertoire"] = True
         specs["definitions"]["datasets"][args.dataset_name]["params"]["metadata_file"] = args.metadata_file

--- a/source/api/galaxy/build_yaml_from_arguments.py
+++ b/source/api/galaxy/build_yaml_from_arguments.py
@@ -3,6 +3,8 @@ import glob
 import itertools as it
 import os
 import sys
+import logging
+import warnings
 
 import yaml
 
@@ -250,12 +252,17 @@ def parse_commandline_arguments(args):
     parser.add_argument("-r", "--reads", choices=[ReadsType.UNIQUE.value, ReadsType.ALL.value], nargs="+", default=[ReadsType.UNIQUE.value],
                         help="Whether k-mer counts should be scaled by unique clonotypes or all observed receptor sequences")
 
+
     return parser.parse_args(args)
 
 
 def main(args):
+    logging.basicConfig(filename="build_yaml_from_args_log.txt", level=logging.INFO, format='%(asctime)s %(levelname)s: %(message)s')
+    warnings.showwarning = lambda message, category, filename, lineno, file=None, line=None: logging.warning(message)
+
     parsed_args = parse_commandline_arguments(args)
     check_arguments(parsed_args)
+
     specs = build_specs(parsed_args)
 
     PathBuilder.build(parsed_args.output_path)

--- a/source/data_model/cell/CellList.py
+++ b/source/data_model/cell/CellList.py
@@ -1,4 +1,4 @@
-from collections import MutableSequence
+from collections.abc import MutableSequence
 
 from source.data_model.cell.Cell import Cell
 from source.util.ParameterValidator import ParameterValidator

--- a/source/data_model/receptor/BCKReceptor.py
+++ b/source/data_model/receptor/BCKReceptor.py
@@ -1,0 +1,20 @@
+from uuid import uuid4
+
+from source.data_model.receptor.Receptor import Receptor
+from source.data_model.receptor.receptor_sequence.ReceptorSequence import ReceptorSequence
+
+
+class BCKReceptor(Receptor):
+
+    def __init__(self, heavy: ReceptorSequence = None, kappa: ReceptorSequence = None, metadata: dict = None,
+                 identifier: str = None):
+        self.heavy = heavy
+        self.kappa = kappa
+        self.metadata = metadata
+        self.identifier = uuid4().hex if identifier is None else identifier
+
+    def get_chains(self):
+        return ["heavy", "kappa"]
+
+    def get_attribute(self, name: str):
+        raise NotImplementedError

--- a/source/data_model/receptor/ChainPair.py
+++ b/source/data_model/receptor/ChainPair.py
@@ -5,8 +5,8 @@ from source.data_model.receptor.receptor_sequence.Chain import Chain
 
 class ChainPair(Enum):
 
-    TRA_TRB = sorted([Chain.ALPHA.value, Chain.BETA.value])
-    TRG_TRD = sorted([Chain.GAMMA.value, Chain.DELTA.value])
-    IGH_IGL = sorted([Chain.HEAVY.value, Chain.LIGHT.value])
-    IGH_IGK = sorted([Chain.HEAVY.value, Chain.KAPPA.value])
+    TRA_TRB = (Chain.ALPHA.value, Chain.BETA.value)
+    TRG_TRD = (Chain.GAMMA.value, Chain.DELTA.value)
+    IGH_IGL = (Chain.HEAVY.value, Chain.LIGHT.value)
+    IGH_IGK = (Chain.HEAVY.value, Chain.KAPPA.value)
 

--- a/source/data_model/receptor/ReceptorBuilder.py
+++ b/source/data_model/receptor/ReceptorBuilder.py
@@ -1,7 +1,9 @@
 import itertools
 from typing import List
+import warnings
 
 from source.data_model.receptor.BCReceptor import BCReceptor
+from source.data_model.receptor.BCKReceptor import BCKReceptor
 from source.data_model.receptor.ChainPair import ChainPair
 from source.data_model.receptor.Receptor import Receptor
 from source.data_model.receptor.TCABReceptor import TCABReceptor
@@ -10,18 +12,22 @@ from source.data_model.receptor.receptor_sequence.Chain import Chain
 from source.data_model.receptor.receptor_sequence.ReceptorSequenceList import ReceptorSequenceList
 
 
+
+
 class ReceptorBuilder:
 
     @classmethod
     def build_object(cls, sequences: dict, identifier: str = None, metadata: dict = None) -> Receptor:
-        chains = sorted(list(sequences.keys()))
-        if chains == ChainPair.TRA_TRB.value or chains == [item.lower() for item in ChainPair.TRA_TRB.value]:
+        if all(chain in ChainPair.TRA_TRB.value for chain in sequences.keys()):
             return TCABReceptor(alpha=sequences[Chain.ALPHA.value], beta=sequences[Chain.BETA.value], identifier=identifier, metadata=metadata)
-        elif chains == ChainPair.TRG_TRD.value or chains == [item.lower() for item in ChainPair.TRG_TRD.value]:
+        elif all(chain in ChainPair.TRG_TRD.value for chain in sequences.keys()):
             return TCGDReceptor(gamma=sequences[Chain.GAMMA.value], delta=sequences[Chain.DELTA.value], identifier=identifier, metadata=metadata)
-        elif chains == ChainPair.IGH_IGL.value or chains == [item.lower() for item in ChainPair.IGH_IGL.value]:
+        elif all(chain in ChainPair.IGH_IGL.value for chain in sequences.keys()):
             return BCReceptor(heavy=sequences[Chain.HEAVY.value], light=sequences[Chain.LIGHT.value], identifier=identifier, metadata=metadata)
+        elif all(chain in ChainPair.IGH_IGK.value for chain in sequences.keys()):
+            return BCKReceptor(heavy=sequences[Chain.HEAVY.value], kappa=sequences[Chain.KAPPA.value], identifier=identifier, metadata=metadata)
         else:
+            warnings.warn(f"ReceptorBuilder: attempt to build receptor with chains {sequences.keys()}, returning None...")
             return None
 
     @classmethod

--- a/source/data_model/receptor/receptor_sequence/ReceptorSequenceList.py
+++ b/source/data_model/receptor/receptor_sequence/ReceptorSequenceList.py
@@ -1,4 +1,4 @@
-from collections import MutableSequence
+from collections.abc import MutableSequence
 
 from source.data_model.receptor.receptor_sequence.ReceptorSequence import ReceptorSequence
 from source.util.ParameterValidator import ParameterValidator

--- a/source/reports/ml_reports/CoefficientPlottingSettingList.py
+++ b/source/reports/ml_reports/CoefficientPlottingSettingList.py
@@ -1,4 +1,4 @@
-from collections import MutableSequence
+from collections.abc import MutableSequence
 
 from source.reports.ml_reports.CoefficientPlottingSetting import CoefficientPlottingSetting
 from source.util.ParameterValidator import ParameterValidator

--- a/source/util/ImportHelper.py
+++ b/source/util/ImportHelper.py
@@ -15,6 +15,7 @@ from source.data_model.dataset import Dataset
 from source.data_model.dataset.ReceptorDataset import ReceptorDataset
 from source.data_model.dataset.RepertoireDataset import RepertoireDataset
 from source.data_model.dataset.SequenceDataset import SequenceDataset
+from source.data_model.receptor.BCKReceptor import BCKReceptor
 from source.data_model.receptor.BCReceptor import BCReceptor
 from source.data_model.receptor.ChainPair import ChainPair
 from source.data_model.receptor.Receptor import Receptor
@@ -306,6 +307,11 @@ class ImportHelper:
         elif params.receptor_chains == ChainPair.IGH_IGL:
             receptor = BCReceptor(heavy=first_sequence,
                                   light=second_sequence,
+                                  identifier=identifier,
+                                  metadata={**first_sequence.metadata.custom_params})
+        elif params.receptor_chains == ChainPair.IGH_IGK:
+            receptor = BCKReceptor(heavy=first_sequence,
+                                  kappa=second_sequence,
                                   identifier=identifier,
                                   metadata={**first_sequence.metadata.custom_params})
         else:

--- a/test/api/galaxy/test_build_dataset_yaml.py
+++ b/test/api/galaxy/test_build_dataset_yaml.py
@@ -44,7 +44,7 @@ class MyTestCase(unittest.TestCase):
         os.chdir(path)
 
         yamlbuilder_main(["-r", "VDJdb", "-o", path, "-f", "sequence.yaml", "-p", "False"])
-        yamlbuilder_main(["-r", "VDJdb", "-o", path, "-f", "receptor.yaml", "-p", "True", "-c", "TRA_TRB"])
+        yamlbuilder_main(["-r", "VDJdb", "-o", path, "-f", "receptor.yaml", "-p", "True", "-c", "TRG_TRD"])
         yamlbuilder_main(["-r", "VDJdb", "-o", path, "-f", "repertoire.yaml", "-m", "metadata.csv"])
 
         with open(f"{path}/sequence.yaml", "r") as file:
@@ -57,7 +57,7 @@ class MyTestCase(unittest.TestCase):
             loaded_receptor = yaml.load(file)
 
             self.assertDictEqual(loaded_receptor["definitions"]["datasets"], {"dataset": {"format": "VDJdb", "params":
-                {"path": "./", "is_repertoire": False, "paired": True, "receptor_chains": "TRA_TRB", "region_type": RegionType.IMGT_CDR3.name, "result_path": "./"}}})
+                {"path": "./", "is_repertoire": False, "paired": True, "receptor_chains": "TRG_TRD", "region_type": RegionType.IMGT_CDR3.name, "result_path": "./"}}})
 
         with open(f"{path}/repertoire.yaml", "r") as file:
             loaded_receptor = yaml.load(file)

--- a/test/api/galaxy/test_build_dataset_yaml.py
+++ b/test/api/galaxy/test_build_dataset_yaml.py
@@ -5,6 +5,7 @@ import yaml
 import pandas as pd
 
 from source.api.galaxy.build_dataset_yaml import main as yamlbuilder_main
+from source.api.galaxy.build_dataset_yaml import build_metadata_column_mapping
 from source.data_model.receptor.RegionType import RegionType
 from source.dsl.ImmuneMLParser import ImmuneMLParser
 from source.environment.EnvironmentSettings import EnvironmentSettings
@@ -32,6 +33,11 @@ class MyTestCase(unittest.TestCase):
 
         pd.DataFrame(metadata).to_csv(path + "metadata.csv")
 
+    def test_build_metadata_column_mapping(self):
+        self.assertDictEqual({}, build_metadata_column_mapping("''"))
+        self.assertDictEqual({"a": "a"}, build_metadata_column_mapping("'a',"))
+        self.assertDictEqual({"a": "a", "b": "b"}, build_metadata_column_mapping("'b',a"))
+
     def test_main(self):
 
         path = f"{EnvironmentSettings.tmp_test_path}dataset_yaml/"
@@ -43,21 +49,21 @@ class MyTestCase(unittest.TestCase):
 
         os.chdir(path)
 
-        yamlbuilder_main(["-r", "VDJdb", "-o", path, "-f", "sequence.yaml", "-p", "False"])
-        yamlbuilder_main(["-r", "VDJdb", "-o", path, "-f", "receptor.yaml", "-p", "True", "-c", "TRG_TRD"])
+        yamlbuilder_main(["-r", "VDJdb", "-o", path, "-f", "sequence.yaml", "-p", "False", "-a", "a,b"])
+        yamlbuilder_main(["-r", "VDJdb", "-o", path, "-f", "receptor.yaml", "-p", "True", "-c", "TRG_TRD", "-a", "'c'"])
         yamlbuilder_main(["-r", "VDJdb", "-o", path, "-f", "repertoire.yaml", "-m", "metadata.csv"])
 
         with open(f"{path}/sequence.yaml", "r") as file:
             loaded_receptor = yaml.load(file)
 
             self.assertDictEqual(loaded_receptor["definitions"]["datasets"], {"dataset": {"format": "VDJdb", "params":
-                {"path": "./", "is_repertoire": False, "paired": False, "region_type": RegionType.IMGT_CDR3.name, "result_path": "./"}}})
+                {"path": "./", "is_repertoire": False, "paired": False, "metadata_column_mapping": {"a":"a", "b":"b"}, "region_type": RegionType.IMGT_CDR3.name, "result_path": "./"}}})
 
         with open(f"{path}/receptor.yaml", "r") as file:
             loaded_receptor = yaml.load(file)
 
             self.assertDictEqual(loaded_receptor["definitions"]["datasets"], {"dataset": {"format": "VDJdb", "params":
-                {"path": "./", "is_repertoire": False, "paired": True, "receptor_chains": "TRG_TRD", "region_type": RegionType.IMGT_CDR3.name, "result_path": "./"}}})
+                {"path": "./", "is_repertoire": False, "paired": True, "receptor_chains": "TRG_TRD", "metadata_column_mapping": {"c":"c"}, "region_type": RegionType.IMGT_CDR3.name, "result_path": "./"}}})
 
         with open(f"{path}/repertoire.yaml", "r") as file:
             loaded_receptor = yaml.load(file)


### PR DESCRIPTION
-> add metadata column mapping for simple create dataset galaxy interface. for now the column name is used both as key and value (i.e. label corresponds directly to original column name), as I think this is easiest to understand for the user
-> write warnings to logger, and import MutableSequence from collections.abc to remove deprecationwarning
-> do not sort ChainPair (gave bug when TRG_TRD was selected)
-> added BCReceptor with kappa chain (now named BCKReceptor, can be changed if necessary..) because it is present in 10xGenomics files 
