### PR TITLE
Receptor file discovery

### DIFF
--- a/source/IO/dataset_import/IRISImport.py
+++ b/source/IO/dataset_import/IRISImport.py
@@ -177,7 +177,7 @@ class IRISImport(DataImport):
 
         iris_params = IRISImportParams.build_object(**params)
 
-        filenames = glob(iris_params.path + "*.tsv")
+        filenames = ImportHelper.get_sequence_filenames(iris_params.path, dataset_name)
         file_index = 0
         dataset_filenames = []
 

--- a/source/IO/dataset_import/SingleLineReceptorImport.py
+++ b/source/IO/dataset_import/SingleLineReceptorImport.py
@@ -16,6 +16,7 @@ from source.data_model.receptor.RegionType import RegionType
 from source.data_model.receptor.receptor_sequence.Chain import Chain
 from source.data_model.receptor.receptor_sequence.ReceptorSequence import ReceptorSequence
 from source.data_model.receptor.receptor_sequence.SequenceMetadata import SequenceMetadata
+from source.util.ImportHelper import ImportHelper
 from source.util.PathBuilder import PathBuilder
 
 
@@ -109,7 +110,8 @@ class SingleLineReceptorImport(DataImport):
     @staticmethod
     def import_dataset(params, dataset_name: str) -> ReceptorDataset:
         generic_params = DatasetImportParams.build_object(**params)
-        filenames = SingleLineReceptorImport._extract_filenames(generic_params)
+
+        filenames = ImportHelper.get_sequence_filenames(params.path, dataset_name)
 
         PathBuilder.build(generic_params.result_path, warn_if_exists=True)
 
@@ -161,20 +163,6 @@ class SingleLineReceptorImport(DataImport):
                                                                      ["v_gene", 'j_gene', "count", "identifier"] + chain_names)}))
 
         return ReceptorDataset.build(elements, generic_params.sequence_file_size, generic_params.result_path)
-
-    @staticmethod
-    def _extract_filenames(params: DatasetImportParams) -> List[str]:
-        if os.path.isdir(params.path):
-            filenames = list(glob.glob(params.path + "*.tsv" if params.separator == "\t" else "*.csv"))
-        elif os.path.isfile(params.path):
-            filenames = [params.path]
-        else:
-            raise ValueError(f"SingleLineReceptorImport: path '{params.path}' given in YAML specification is not a valid path to receptor files. "
-                             f"This parameter can either point to a single file with receptor data or to a directory where a list of receptor data "
-                             f"files are stored directly.")
-
-        logging.info(f"SingleLineReceptorImport: importing from receptor files: \n{str([os.path.basename(file) for file in filenames])[1:-1]}")
-        return filenames
 
     @staticmethod
     def get_documentation():

--- a/source/IO/dataset_import/SingleLineReceptorImport.py
+++ b/source/IO/dataset_import/SingleLineReceptorImport.py
@@ -111,7 +111,7 @@ class SingleLineReceptorImport(DataImport):
     def import_dataset(params, dataset_name: str) -> ReceptorDataset:
         generic_params = DatasetImportParams.build_object(**params)
 
-        filenames = ImportHelper.get_sequence_filenames(params.path, dataset_name)
+        filenames = ImportHelper.get_sequence_filenames(generic_params.path, dataset_name)
 
         PathBuilder.build(generic_params.result_path, warn_if_exists=True)
 

--- a/source/util/ImportHelper.py
+++ b/source/util/ImportHelper.py
@@ -193,12 +193,24 @@ class ImportHelper:
         '''
         return df[column_name].apply(lambda gene_col: gene_col.rsplit("*", maxsplit=1)[0])
 
-    @staticmethod #
-    def import_sequence_dataset(import_class, params, dataset_name: str): # todo remove args kwargs
+    @staticmethod
+    def get_sequence_filenames(path, dataset_name):
+        if os.path.isfile(path):
+            filenames = [path]
+        elif os.path.isdir(path):
+            filenames = glob(os.path.join(path, "*"))
+        else:
+            raise ValueError(f"ImportHelper: path '{path}' given in YAML specification is not a valid path. "
+                             f"This parameter can either point to a single file with immune receptor data or to a directory containing such files.")
+
+        assert len(filenames) >= 1, f"ImportHelper: the dataset {dataset_name} cannot be imported, no files were found under {path}."
+        return filenames
+
+    @staticmethod
+    def import_sequence_dataset(import_class, params, dataset_name: str):
         PathBuilder.build(params.result_path)
 
-        filenames = [params.path] if os.path.isfile(params.path) else glob(params.path + "*.tsv")
-        assert len(filenames) >= 1, f"ImportHelper: the dataset {dataset_name} cannot be imported, no files were found under {params.path}."
+        filenames = ImportHelper.get_sequence_filenames(params.path, dataset_name)
 
         file_index = 0
         dataset_filenames = []

--- a/test/IO/dataset_import/test_AIRRImport.py
+++ b/test/IO/dataset_import/test_AIRRImport.py
@@ -52,7 +52,7 @@ rep2.tsv,2""")
     def test_import_repertoire_dataset(self):
         path = EnvironmentSettings.root_path + "test/tmp/ioairr/"
         PathBuilder.build(path)
-        self.create_dummy_dataset(path, add_metadata=True)
+        self.create_dummy_dataset(path, True)
 
         column_mapping = self.get_column_mapping()
         params = {"is_repertoire": True, "result_path": path, "path": path, "metadata_file": path + "metadata.csv",
@@ -79,7 +79,7 @@ rep2.tsv,2""")
     def test_sequence_dataset(self):
         path = EnvironmentSettings.root_path + "test/tmp/ioairr/"
         PathBuilder.build(path)
-        self.create_dummy_dataset(path, add_metadata=False)
+        self.create_dummy_dataset(path, False)
 
         column_mapping = self.get_column_mapping()
         params = {"is_repertoire": False, "result_path": path, "path": path,

--- a/test/IO/dataset_import/test_IGoRImport.py
+++ b/test/IO/dataset_import/test_IGoRImport.py
@@ -9,7 +9,7 @@ from source.util.PathBuilder import PathBuilder
 
 class TestIGoRImport(TestCase):
 
-    def write_dummy_files(self, path):
+    def write_dummy_files(self, path, add_metadata):
         file1_content = """seq_index,nt_CDR3,anchors_found,is_inframe
 0,TGTGCGAGAGATCCTAGAAGCAGTGGCTGGAGATCAAAACCTACTGG,1,0
 1,TGTGCGAGAGTTAATCGGCATATTGTGGTGGTGACTGCTATTATGACCGGGTAAAACTGGTTCGACCCCTGG,1,1
@@ -31,8 +31,9 @@ class TestIGoRImport(TestCase):
         with open(path + "rep2.tsv", "w") as file:
             file.writelines(file2_content)
 
-        with open(path + "metadata.csv", "w") as file:
-            file.writelines("""filename,subject_id
+        if add_metadata:
+            with open(path + "metadata.csv", "w") as file:
+                file.writelines("""filename,subject_id
 rep1.tsv,1
 rep2.tsv,2""")
 
@@ -41,7 +42,7 @@ rep2.tsv,2""")
         path = EnvironmentSettings.root_path + "test/tmp/io_igor_load/"
 
         PathBuilder.build(path)
-        self.write_dummy_files(path)
+        self.write_dummy_files(path, True)
 
         params = DefaultParamsLoader.load(EnvironmentSettings.default_params_path + "datasets/", "igor")
         params["is_repertoire"] = True
@@ -63,7 +64,7 @@ rep2.tsv,2""")
         path = EnvironmentSettings.root_path + "test/tmp/io_igor_load/"
 
         PathBuilder.build(path)
-        self.write_dummy_files(path)
+        self.write_dummy_files(path, True)
 
         params = DefaultParamsLoader.load(EnvironmentSettings.default_params_path + "datasets/", "igor")
         params["is_repertoire"] = True
@@ -88,7 +89,7 @@ rep2.tsv,2""")
         path = EnvironmentSettings.root_path + "test/tmp/io_igor_load/"
 
         PathBuilder.build(path)
-        self.write_dummy_files(path)
+        self.write_dummy_files(path, False)
 
         params = DefaultParamsLoader.load(EnvironmentSettings.default_params_path + "datasets/", "igor")
         params["is_repertoire"] = False

--- a/test/IO/dataset_import/test_ImmunoSEQRearrangementImport.py
+++ b/test/IO/dataset_import/test_ImmunoSEQRearrangementImport.py
@@ -11,7 +11,7 @@ from source.util.ImportHelper import ImportHelper
 
 
 class TestImmunoSEQRearrangementImport(TestCase):
-    def build_dummy_dataset(self, path):
+    def build_dummy_dataset(self, path, add_metadata):
 
         rep1text = """rearrangement	amino_acid	frame_type	rearrangement_type	templates	reads	frequency	productive_frequency	cdr3_length	v_family	v_gene	v_allele	d_family	d_gene	d_allele	j_family	j_gene	j_allele	v_deletions	d5_deletions	d3_deletions	j_deletions	n2_insertions	n1_insertions	v_index	n1_index	n2_index	d_index	j_index	v_family_ties	v_gene_ties	v_allele_ties	d_family_ties	d_gene_ties	d_allele_ties	j_family_ties	j_gene_ties	j_allele_ties	sequence_tags	v_shm_count	v_shm_indexes	antibody	sample_name	species	locus	product_subtype	kit_pool	total_templates	productive_templates	outofframe_templates	stop_templates	dj_templates	total_rearrangements	productive_rearrangements	outofframe_rearrangements	stop_rearrangements	dj_rearrangements	total_reads	total_productive_reads	total_outofframe_reads	total_stop_reads	total_dj_reads	productive_clonality	productive_entropy	sample_clonality	sample_entropy	sample_amount_ng	sample_cells_mass_estimate	fraction_productive_of_cells_mass_estimate	sample_cells	fraction_productive_of_cells	max_productive_frequency	max_frequency	counting_method	primer_set	release_date	sample_tags	fraction_productive	order_name	kit_id	total_t_cells
 ACTCTGACTGTGAGCAACATGAGCCCTGAAGACAGCAGCATATATCTCTGCAGCGTTGAAGAATCCTACGAGCAGTACTTCGGGCCG	CSVEESYEQYF	In	VJ	10	311	7.66134773699554E-5	9.602057989637805E-5	33	TCRBV29	TCRBV29-01	01		unresolved		TCRBJ02	TCRBJ02-07	01	0	0	0	1	1	0	48	-1	62	-1	63										null	null	null	Vb 4	HIP00110	Human	TCRB	Deep	null	224859	179411	41463	3983	0	130940	104850	24105	1985	0	4059338	3238889	748535	71914	0	0.100719467	14.9981718	0.1101579	15.1260223	3636.47998	559458	0.3206871650776287	0	0.0	0.0137189021	0.0191940162	v2	Human-TCRB-PD1x	2013-12-13 22:23:05.529	Age:55 Years,Biological Sex:Male,Cohort:Cohort 01,Ethnic Group:Unknown Ethnicity,HLA MHC class I:HLA-A*03,HLA MHC class I:HLA-A*24,HLA MHC class I:HLA-B*07,Inferred CMV status (cross-validation): Inferred CMV -,Inferred CMV status: Inferred CMV -,Inferred HLA type:Inferred HLA-A*03,Inferred HLA type:Inferred HLA-A*24,Inferred HLA type:Inferred HLA-B*07,Racial Group:Unknown racial group,Species:Human,Tissue Source:gDNA,Tissue Source:PBMC,Tissue Source:Peripheral blood lymphocytes (PBL),Tissue Source:T cells,Virus Diseases:Cytomegalovirus -	0.7978822284186979	null	null	0
@@ -54,16 +54,17 @@ ACAGTGACCAGTGCCCATCCTGAAGACAGCAGCTTCTACATCTGCAGTGCTAGATCCACCTTAGAGTACGAGCAGTACTT
         with open(path + "rep2.tsv", "w") as file:
             file.writelines(rep2text)
 
-        with open(path + "metadata.csv", "w") as file:
-            file.writelines(
-                """filename,chain,subject_id,coeliac status (yes/no)
+        if add_metadata:
+            with open(path + "metadata.csv", "w") as file:
+                file.writelines(
+                    """filename,chain,subject_id,coeliac status (yes/no)
 rep1.tsv,TRA,1234,no
 rep2.tsv,TRB,1234a,no"""
             )
 
     def test_repertoire_import(self):
         path = EnvironmentSettings.root_path + "test/tmp/adaptive/"
-        self.build_dummy_dataset(path)
+        self.build_dummy_dataset(path, True)
 
         params = DefaultParamsLoader.load(EnvironmentSettings.default_params_path + "datasets/", "ImmunoSEQRearrangement")
         params["is_repertoire"] = True
@@ -101,7 +102,7 @@ rep2.tsv,TRB,1234a,no"""
 
     def test_sequence_import(self):
         path = EnvironmentSettings.root_path + "test/tmp/adaptive/"
-        self.build_dummy_dataset(path)
+        self.build_dummy_dataset(path, False)
 
         params = DefaultParamsLoader.load(EnvironmentSettings.default_params_path + "datasets/", "ImmunoSEQRearrangement")
         params["is_repertoire"] = False

--- a/test/IO/dataset_import/test_OLGAImport.py
+++ b/test/IO/dataset_import/test_OLGAImport.py
@@ -8,7 +8,7 @@ from source.util.PathBuilder import PathBuilder
 
 class TestOLGALoader(TestCase):
 
-    def write_dummy_files(self, path):
+    def write_dummy_files(self, path, add_metadata):
         file1_content = """TGTGCCAGCAGTTTATCGCCGGGACTGGCCTACGAGCAGTACTTC	CASSLSPGLAYEQYF	TRBV27	TRBJ2-7
 TGTGCCAGCAAAGTCAGAATTGCTGCAACTAATGAAAAACTGTTTTTT	CASKVRIAATNEKLFF	TRBV5-6	TRBJ1-4
 TGCAGTGCCGACTCCAAGAACAGAGGAGCGGGGGGGGAGGCAAGCTCCTACGAGCAGTACTTC	CSADSKNRGAGGEASSYEQYF	TRBV20-1	TRBJ2-7"""
@@ -22,8 +22,9 @@ TGTGCTAGTGGGAAAAATCGGGACTCTAGTGCAGGCCAAGAGACCCAGTACTTC	CASGKNRDSSAGQETQYF	TRBV12
         with open(path + "rep2.tsv", "w") as file:
             file.writelines(file2_content)
 
-        with open(path + "metadata.csv", "w") as file:
-            file.writelines("""filename,subject_id
+        if add_metadata:
+            with open(path + "metadata.csv", "w") as file:
+                file.writelines("""filename,subject_id
 rep1.tsv,1
 rep2.tsv,2""")
 
@@ -32,7 +33,7 @@ rep2.tsv,2""")
         path = EnvironmentSettings.root_path + "test/tmp/io_olga_load/"
 
         PathBuilder.build(path)
-        self.write_dummy_files(path)
+        self.write_dummy_files(path, True)
         dataset = OLGAImport.import_dataset({"is_repertoire": True, "result_path": path, "metadata_file": path + "metadata.csv",
                                              "columns_to_load": None, "separator": "\t", "region_type": "IMGT_CDR3",
                                              "path": path, "batch_size": 4}, "olga_repertoire_dataset")
@@ -62,7 +63,7 @@ rep2.tsv,2""")
         path = EnvironmentSettings.root_path + "test/tmp/io_olga_load/"
 
         PathBuilder.build(path)
-        self.write_dummy_files(path)
+        self.write_dummy_files(path, False)
         dataset = OLGAImport.import_dataset({"is_repertoire": False, "paired": False, "result_path": path, "metadata_file": path + "metadata.csv",
                                              "columns_to_load": None, "separator": "\t", "region_type": "IMGT_CDR3",
                                              "path": path, "batch_size": 4}, "olga_sequence_dataset")

--- a/test/IO/dataset_import/test_genericImport.py
+++ b/test/IO/dataset_import/test_genericImport.py
@@ -7,7 +7,7 @@ from source.util.PathBuilder import PathBuilder
 
 
 class TestGenericLoader(TestCase):
-    def make_dummy_dataset(self, path):
+    def make_dummy_dataset(self, path, add_metadata):
         rep1text = """Clone ID	Senior Author	TRAJ Gene	TRAV Gene	CDR3A AA Sequence	TRBV Gene	TRBD Gene	TRBJ Gene	CDR3B AA Sequence	Antigen Protein	Antigen Gene	Antigen Species	Antigen Peptide AA #	Epitope Peptide	MHC Class	HLA Restriction
 1E6	Sewell	TRAJ12	TRAV12-3	CAMRGDSSYKLIF	TRBV12-4	TRBD2	TRBJ2-4	CASSLWEKLAKNIQYF	PPI	INS	Human	12-24	ALWGPDPAAA	MHC I	A*02:01
 4.13	Nepom	TRAJ44	TRAV19	CALSENRGGTASKLTF	TRBV5-1	TRBD1	TRBJ1-1	CASSLVGGPSSEAFF	GAD		Human	555-567		MHC II	DRB1*04:01
@@ -29,15 +29,16 @@ T1D#3 C8	TBD	TRAJ23	TRAV17	CATDAGYNQGGKLIF	TRBV5-1	TRBD2	TRBJ1-3	CASSAGNTIYF	Ins
         with open(path + "rep1.tsv", "w") as file:
             file.writelines(rep1text)
 
-        with open(path + "metadata.csv", "w") as file:
-            file.writelines(
-                """filename,chain,subject_id,coeliac status (yes/no)
+        if add_metadata:
+            with open(path + "metadata.csv", "w") as file:
+                file.writelines(
+                    """filename,chain,subject_id,coeliac status (yes/no)
 rep1.tsv,TRA,1234e,no"""
-            )
+                )
 
     def test_import_repertoire_dataset(self):
         path = EnvironmentSettings.root_path + "test/tmp/generic/"
-        self.make_dummy_dataset(path)
+        self.make_dummy_dataset(path, True)
 
 
         dataset = GenericImport.import_dataset({"is_repertoire": True, "result_path": path, "path": path,
@@ -60,7 +61,7 @@ rep1.tsv,TRA,1234e,no"""
 
     def test_import_sequence_dataset(self):
         path = EnvironmentSettings.root_path + "test/tmp/generic/"
-        self.make_dummy_dataset(path)
+        self.make_dummy_dataset(path, False)
 
 
         dataset = GenericImport.import_dataset({"is_repertoire": False, "paired": False,

--- a/test/IO/dataset_import/test_immunoSEQSampleImport.py
+++ b/test/IO/dataset_import/test_immunoSEQSampleImport.py
@@ -8,7 +8,7 @@ from source.util.PathBuilder import PathBuilder
 
 
 class TestImmunoSEQSampleImport(TestCase):
-    def create_dummy_dataset(self, path):
+    def create_dummy_dataset(self, path, add_metadata):
         rep1text = """nucleotide	aminoAcid	count (templates/reads)	frequencyCount (%)	cdr3Length	vMaxResolved	vFamilyName	vGeneName	vGeneAllele	vFamilyTies	vGeneNameTies	vGeneAlleleTies	dMaxResolved	dFamilyName	dGeneName	dGeneAllele	dFamilyTies	dGeneNameTies	dGeneAlleleTies	jMaxResolved	jFamilyName	jGeneName	jGeneAllele	jFamilyTies	jGeneNameTies	jGeneAlleleTies	vDeletion	n1Insertion	d5Deletion	d3Deletion	n2Insertion	jDeletion	vIndex	n1Index	dIndex	n2Index	jIndex	estimatedNumberGenomes	sequenceStatus	cloneResolved	vOrphon	dOrphon	jOrphon	vFunction	dFunction	jFunction	fractionNucleated	vAlignLength	vAlignSubstitutionCount	vAlignSubstitutionIndexes	vAlignSubstitutionGeneThreePrimeIndexes	vSeqWithMutations
         GCCATCCCCAACCAGACAGCTCTTTACTTCTGTGCCACCAGTGATCAACTTAACCGTTGGGGGACCGGGGAGCTGTTTTTTGGAGAA	CATSDQLNRWGTGELFF	38	0.0017525250196006087	51	TCRBV24	TCRBV24				TCRBV24-01,TCRBV24-or09_02						TCRBD01,TCRBD02	TCRBD01-01,TCRBD02-01		TCRBJ02-02*01	TCRBJ02	TCRBJ02-02	01				3	0	6	1	13	5	30	45	58	-1	63	38	In	VDJ												
         GGGTTGGAGTCGGCTGCTCCCTCCCAAACATCTGTGTACTTCTGTGCCAGCAAGGACGGCGACACCGGGGAGCTGTTTTTTGGAGAA	CASKDGDTGELFF	48	0.002213715814232348	39	TCRBV06	TCRBV06				TCRBV06-02,TCRBV06-03						TCRBD01,TCRBD02	TCRBD01-01,TCRBD02-01		TCRBJ02-02*01	TCRBJ02	TCRBJ02-02	01				7	4	1	7	1	3	42	52	53	57	61	48	In	VDJ												
@@ -35,17 +35,18 @@ class TestImmunoSEQSampleImport(TestCase):
         with open(path + "rep1.tsv", "w") as file:
             file.writelines(rep1text)
 
-        with open(path + "metadata.csv", "w") as file:
-            file.writelines(
-                """filename,chain,subject_id,coeliac status (yes/no)
+        if add_metadata:
+            with open(path + "metadata.csv", "w") as file:
+                file.writelines(
+                    """filename,chain,subject_id,coeliac status (yes/no)
 rep1.tsv,TRA,1234a,no"""
-            )
+                )
 
 
     def test_import_repertoire_dataset(self):
         path = EnvironmentSettings.root_path + "test/tmp/immunoseq/"
 
-        self.create_dummy_dataset(path)
+        self.create_dummy_dataset(path, True)
 
 
         params = DefaultParamsLoader.load(EnvironmentSettings.default_params_path + "datasets/", "ImmunoSEQSample")
@@ -69,7 +70,7 @@ rep1.tsv,TRA,1234a,no"""
     def test_import_sequence_dataset(self):
         path = EnvironmentSettings.root_path + "test/tmp/immunoseq/"
 
-        self.create_dummy_dataset(path)
+        self.create_dummy_dataset(path, False)
 
         params = DefaultParamsLoader.load(EnvironmentSettings.default_params_path + "datasets/", "ImmunoSEQSample")
         params["is_repertoire"] = False

--- a/test/IO/dataset_import/test_miXCRImport.py
+++ b/test/IO/dataset_import/test_miXCRImport.py
@@ -78,7 +78,7 @@ rep2.tsv,2""")
     def test_load_sequence_dataset(self):
         path = EnvironmentSettings.root_path + "test/tmp/mixcr/"
         PathBuilder.build(path)
-        self.create_dummy_dataset(path, add_metadata=True)
+        self.create_dummy_dataset(path, add_metadata=False)
 
         params = DefaultParamsLoader.load(EnvironmentSettings.default_params_path + "datasets/", "mixcr")
         params["is_repertoire"] = False

--- a/test/dsl/test_importParser.py
+++ b/test/dsl/test_importParser.py
@@ -28,9 +28,10 @@ class TestImportParser(TestCase):
 15760	TRA	CALRLNNQGGKLIF	TRAV9-2*01	TRAJ23*01	HomoSapiens	HLA-A*03:01	B2M	MHCI	KLGGALQAK	IE1	CMV	https://www.10xgenomics.com/resources/application-notes/a-new-way-of-exploring-immunity-linking-highly-multiplexed-antigen-recognition-to-immune-repertoire-and-phenotype/#	{"frequency": "1/25584", "identification": "dextramer-sort", "sequencing": "rna-seq", "singlecell": "yes", "verification": ""}	{"cell.subset": "", "clone.id": "", "donor.MHC": "", "donor.MHC.method": "", "epitope.id": "", "replica.id": "", "samples.found": 1, "structure.id": "", "studies.found": 1, "study.id": "", "subject.cohort": "", "subject.id": "3", "tissue": ""}	{"cdr3": "CALRLNNQGGKLIF", "cdr3_old": "CALRLNNQGGKLIF", "fixNeeded": false, "good": true, "jCanonical": true, "jFixType": "NoFixNeeded", "jId": "TRAJ23*01", "jStart": 6, "vCanonical": true, "vEnd": 3, "vFixType": "NoFixNeeded", "vId": "TRAV9-2*01"}	0
                 """
         path = EnvironmentSettings.root_path + "test/tmp/dslimportparservdj/"
-        PathBuilder.build(path)
+        data_path = EnvironmentSettings.root_path + "test/tmp/dslimportparservdj/receptor_data/"
+        PathBuilder.build(data_path)
 
-        with open(path + "receptors.tsv", "w") as file:
+        with open(data_path + "receptors.tsv", "w") as file:
             file.writelines(file_content)
 
         st, desc = ImportParser.parse({
@@ -41,7 +42,7 @@ class TestImportParser(TestCase):
                         "is_repertoire": False,
                         "paired": True,
                         "receptor_chains": "TRA_TRB",
-                        "path": path
+                        "path": data_path
                     }
                 }
             }
@@ -53,7 +54,7 @@ class TestImportParser(TestCase):
 
         shutil.rmtree(path)
 
-    def  test_parse(self):
+    def test_parse(self):
         path = EnvironmentSettings.root_path + "test/tmp/parser/"
 
         PathBuilder.build(path + "tmp_input/")


### PR DESCRIPTION
Discover sequence/receptor files with any extension (assume the data folder shouldn't contain irrelevant files)
Clearer error messages when wrong file happens to be in the receptor data folder (for example if someone accidentally has a metadata file there)
Updated tests: make sure input data for sequence/receptor datasets is in its own folder and does not contain other (metadata) files