### PR TITLE
Small fix: add subfolders in exploratory analysis output

### DIFF
--- a/source/workflows/instructions/exploratory_analysis/ExploratoryAnalysisInstruction.py
+++ b/source/workflows/instructions/exploratory_analysis/ExploratoryAnalysisInstruction.py
@@ -69,10 +69,10 @@ class ExploratoryAnalysisInstruction(Instruction):
         return self.state
 
     def run_unit(self, unit: ExploratoryAnalysisUnit, result_path: str) -> ReportResult:
-        unit.dataset = self.preprocess_dataset(unit, result_path)
-        encoded_dataset = self.encode(unit, result_path)
+        unit.dataset = self.preprocess_dataset(unit, result_path + "preprocessed_dataset/")
+        encoded_dataset = self.encode(unit, result_path + "encoded_dataset/")
         unit.report.dataset = encoded_dataset
-        unit.report.result_path = result_path
+        unit.report.result_path = result_path + "report/"
         report_result = unit.report.generate_report()
         return report_result
 

--- a/test/integration_tests/test_exploratoryAnalysisDesignMatrixExporter.py
+++ b/test/integration_tests/test_exploratoryAnalysisDesignMatrixExporter.py
@@ -59,6 +59,6 @@ class TestExploratoryAnalysisDesignMatrixExporter(TestCase):
         process = ExploratoryAnalysisInstruction(units, name="exp")
         process.run(path + "results/")
 
-        self.assertTrue(os.path.isfile(path + "results/exp/analysis_named_analysis_4/design_matrix.csv"))
+        self.assertTrue(os.path.isfile(path + "results/exp/analysis_named_analysis_4/report/design_matrix.csv"))
 
         shutil.rmtree(path)

--- a/test/workflows/instructions/test_exploratoryAnalysisInstruction.py
+++ b/test/workflows/instructions/test_exploratoryAnalysisInstruction.py
@@ -67,8 +67,8 @@ class TestExploratoryAnalysisProcess(TestCase):
         process.run(path + "results/")
 
         self.assertTrue(units["named_analysis_1"].batch_size == 16)
-        self.assertTrue(os.path.isfile(path + "results/exp/analysis_named_analysis_1/sequence_length_distribution.html"))
-        self.assertTrue(os.path.isfile(path + "results/exp/analysis_named_analysis_2/sequence_length_distribution.html"))
-        self.assertTrue(os.path.isfile(path + "results/exp/analysis_named_analysis_3/matching_sequence_overview.tsv"))
+        self.assertTrue(os.path.isfile(path + "results/exp/analysis_named_analysis_1/report/sequence_length_distribution.html"))
+        self.assertTrue(os.path.isfile(path + "results/exp/analysis_named_analysis_2/report/sequence_length_distribution.html"))
+        self.assertTrue(os.path.isfile(path + "results/exp/analysis_named_analysis_3/report/matching_sequence_overview.tsv"))
 
         shutil.rmtree(path)


### PR DESCRIPTION
previously data files were in the same folder as report outputs, now they are in their own subfolders