### PR TITLE
do not check column_mapping and metadata_column_mapping dicts

### DIFF
--- a/source/dsl/ImmuneMLParser.py
+++ b/source/dsl/ImmuneMLParser.py
@@ -126,7 +126,7 @@ class ImmuneMLParser:
             key_to_check = str(key)
             assert re.match(r'^[A-Za-z0-9_]+$', key_to_check), \
                 f"ImmuneMLParser: the keys in the specification can contain only letters, numbers and underscore. Error with key: {key}"
-            if isinstance(specs[key], dict):
+            if isinstance(specs[key], dict) and key not in ["column_mapping", "metadata_column_mapping"]:
                 ImmuneMLParser.check_keys(specs[key])
 
     @staticmethod

--- a/source/workflows/instructions/quickstart.py
+++ b/source/workflows/instructions/quickstart.py
@@ -19,7 +19,10 @@ class Quickstart:
                     "d1": {
                         "format": "RandomRepertoireDataset",
                         "params": {
-                            "labels": {"CD": {True: 0.5, False: 0.5}}
+                            "labels": {"CD": {True: 0.5, False: 0.5}},
+                            "column_mapping": {
+                                "a": "b"
+                            }
                         }
                     }
                 },

--- a/source/workflows/instructions/quickstart.py
+++ b/source/workflows/instructions/quickstart.py
@@ -20,9 +20,6 @@ class Quickstart:
                         "format": "RandomRepertoireDataset",
                         "params": {
                             "labels": {"CD": {True: 0.5, False: 0.5}},
-                            "column_mapping": {
-                                "a": "b"
-                            }
                         }
                     }
                 },

--- a/source/workflows/instructions/quickstart.py
+++ b/source/workflows/instructions/quickstart.py
@@ -19,7 +19,7 @@ class Quickstart:
                     "d1": {
                         "format": "RandomRepertoireDataset",
                         "params": {
-                            "labels": {"CD": {True: 0.5, False: 0.5}},
+                            "labels": {"CD": {True: 0.5, False: 0.5}}
                         }
                     }
                 },


### PR DESCRIPTION
do not check column_mapping and metadata_column_mapping dict keys. This is necessary for the Create Dataset galaxy tool when using it with VDJdb input, because it contains columns that have . or ' ' inside their names, which could be used for the metadata column mapping. 