### PR TITLE
Small fix: optional DeepRC/TCRDist dependencies

### DIFF
--- a/docs/source/FAQ.rst
+++ b/docs/source/FAQ.rst
@@ -25,6 +25,13 @@ When installing all requirements from requirements.txt, there is afterward an er
 
 This issue might be helpful: https://github.com/yaml/pyyaml/issues/291. Try installing yaml manually with a specific version.
 
+When installing immuneML, I get an error (RuntimeError: autoreconf -fi failed), what should I do?
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Mac users who try to install immuneML with the :code:`TCRDist` extra might receive an error saying :code:`RuntimeError: autoreconf -fi failed`.
+This is due to an issue with the TCRDist dependency parasail. Try installing immuneML without the :code:`TCRDist` extra.
+If you still want to use the TCRDist dependency, `this GitHub issue <https://github.com/jeffdaily/parasail-python/issues/32>`_ might be helpful.
+
+
 When should I install immuneML with R dependencies?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 In most cases, it is adviced to install immuneML without R dependencies. The immuneML core functionality does not

--- a/docs/source/FAQ.rst
+++ b/docs/source/FAQ.rst
@@ -25,12 +25,6 @@ When installing all requirements from requirements.txt, there is afterward an er
 
 This issue might be helpful: https://github.com/yaml/pyyaml/issues/291. Try installing yaml manually with a specific version.
 
-When installing immuneML, I get an error (RuntimeError: autoreconf -fi failed), what should I do?
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Mac users who try to install immuneML with the :code:`TCRDist` extra might receive an error saying :code:`RuntimeError: autoreconf -fi failed`.
-This is due to an issue with the TCRDist dependency parasail. Try installing immuneML without the :code:`TCRDist` extra.
-If you still want to use the TCRDist dependency, `this GitHub issue <https://github.com/jeffdaily/parasail-python/issues/32>`_ might be helpful.
-
 
 When should I install immuneML with R dependencies?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/installation/install_with_package_manager.rst
+++ b/docs/source/installation/install_with_package_manager.rst
@@ -29,17 +29,20 @@ Steps to install immuneML with Anaconda (tested with version 4.8.3):
 
   sh install_immuneML_R_dependencies.sh
 
-5. Install immuneML including Python dependencies from GitHub using pip:
+5. Install basic immuneML including Python dependencies from GitHub using pip:
 
 .. code-block:: console
 
   pip install git+https://github.com/uio-bmi/immuneML
 
-Alternatively, if you want to install immuneML including all R plots, use:
+Alternatively, if you want to install immuneML including optional extras (R_plots, DeepRC, TCRDist), use:
 
 .. code-block:: console
 
-  pip install git+https://github.com/uio-bmi/immuneML#egg=immuneML[R_plots]
+  pip install git+https://github.com/uio-bmi/immuneML#egg=immuneML[R_plots,DeepRC,TCRDist]
+
+Installing DeepRC and TCRDist dependencies is necessary to use the :ref:`DeepRC` and :ref:`TCRDISTClassifier` ML methods. 
+It is also possible to specify a subset of extras, for example, include only :code:`R_plots`.
 
 6. To validate the installation, run:
 

--- a/docs/source/installation/install_with_package_manager.rst
+++ b/docs/source/installation/install_with_package_manager.rst
@@ -41,7 +41,7 @@ Alternatively, if you want to install immuneML including optional extras (:code:
 
   pip install git+https://github.com/uio-bmi/immuneML#egg=immuneML[DeepRC,TCRDist]
 
-Installing DeepRC and TCRDist dependencies is necessary to use the :ref:`DeepRC` and :ref:`TCRDISTClassifier` ML methods.
+Installing DeepRC and TCRDist dependencies is necessary to use the :ref:`DeepRC` and :ref:`TCRDISTClassifier` ML methods, and corresponding :ref:`DeepRCInterpretation` and :ref:`TCRDistMotifDiscovery` reports.
 It is also possible to specify a subset of extras, for example, include only :code:`DeepRC`.
 
 5. To validate the installation, run:
@@ -112,7 +112,7 @@ Alternatively, if you want to install immuneML including optional extras (:code:
 
   pip install git+https://github.com/uio-bmi/immuneML#egg=immuneML[R_plots,DeepRC,TCRDist]
 
-Installing DeepRC and TCRDist dependencies is necessary to use the :ref:`DeepRC` and :ref:`TCRDISTClassifier` ML methods.
+Installing DeepRC and TCRDist dependencies is necessary to use the :ref:`DeepRC` and :ref:`TCRDISTClassifier` ML methods, and corresponding :ref:`DeepRCInterpretation` and :ref:`TCRDistMotifDiscovery` reports.
 
 6. To validate the installation, run:
 

--- a/docs/source/installation/install_with_package_manager.rst
+++ b/docs/source/installation/install_with_package_manager.rst
@@ -1,7 +1,14 @@
 Install immuneML with a package manager
 =========================================
 
-Steps to install immuneML with Anaconda (tested with version 4.8.3):
+This manual shows how to install immuneML with `Anaconda <https://docs.anaconda.com/anaconda/install/>`_ (tested with version 4.8.3).
+
+While the immuneML core functionalities do not depend on R, R dependencies are necessary to generate certain plots (see: :ref:`When should I install immuneML with R dependencies?`).
+Installing immuneML with R dependencies takes a few more steps. Therefore, both tutorials are shown separately below.
+
+
+Install immuneML without R dependencies
+---------------------------------------
 
 1. Create a directory for immuneML and navigate to the directory:
 
@@ -10,24 +17,17 @@ Steps to install immuneML with Anaconda (tested with version 4.8.3):
   mkdir immuneML/
   cd immuneML/
 
-2. Create a virtual environment using conda, and install dependencies using `environment.yaml <https://drive.google.com/file/d/1Vc7ivHL4z4l3KAyDX8qJ_Lsez_1nEb6e/view?usp=sharing>`_ file:
+2. Create a virtual environment using conda:
 
 .. code-block:: console
 
-  conda env create --prefix immuneml_env/ -f environment.yaml
+  conda create --prefix immuneml_env/ python=3.7.6
 
-3. Activate created environment:
+3. Activate the created environment:
 
 .. code-block:: console
 
   conda activate immuneml_env/
-
-4. Optionally, install additional R dependencies from the script provided `here <https://drive.google.com/file/d/1C0m7bjG7OKfWNVQsgYkE-nXCdvD7mO08/view?usp=sharing>`_
-(note that the immuneML core functionality does not depend on R, it is only necessary to generate certain reports. See: :ref:`When should I install immuneML with R dependencies?`):
-
-.. code-block:: console
-
-  sh install_immuneML_R_dependencies.sh
 
 5. Install basic immuneML including Python dependencies from GitHub using pip:
 
@@ -35,14 +35,84 @@ Steps to install immuneML with Anaconda (tested with version 4.8.3):
 
   pip install git+https://github.com/uio-bmi/immuneML
 
-Alternatively, if you want to install immuneML including optional extras (R_plots, DeepRC, TCRDist), use:
+Alternatively, if you want to install immuneML including optional extras (:code:`DeepRC`, :code:`TCRDist`), use:
+
+.. code-block:: console
+
+  pip install git+https://github.com/uio-bmi/immuneML#egg=immuneML[DeepRC,TCRDist]
+
+Installing DeepRC and TCRDist dependencies is necessary to use the :ref:`DeepRC` and :ref:`TCRDISTClassifier` ML methods.
+It is also possible to specify a subset of extras, for example, include only :code:`DeepRC`.
+
+6. To validate the installation, run:
+
+.. code-block:: console
+
+  immune-ml -h
+
+The output should look like this:
+
+.. code-block:: console
+
+  usage: immune-ml [-h] [--tool TOOL] specification_path result_path
+
+  immuneML command line tool
+
+  positional arguments:
+    specification_path  Path to specification YAML file. Always used to define
+                        the analysis.
+    result_path         Output directory path.
+
+  optional arguments:
+    -h, --help          show this help message and exit
+    --tool TOOL         Name of the tool which calls immuneML. This name will be
+                        used to invoke appropriate API call, which will then do
+                        additional work in tool-dependent way before running
+                        standard immuneML.
+
+
+
+Install immuneML with R dependencies
+---------------------------------------
+
+1. Create a directory for immuneML and navigate to the directory:
+
+.. code-block:: console
+
+  mkdir immuneML/
+  cd immuneML/
+
+2. Create a virtual environment using conda, and install dependencies using the `environment.yaml <https://drive.google.com/file/d/1Vc7ivHL4z4l3KAyDX8qJ_Lsez_1nEb6e/view?usp=sharing>`_ file:
+
+.. code-block:: console
+
+  conda env create --prefix immuneml_env/ -f environment.yaml
+
+3. Activate the created environment:
+
+.. code-block:: console
+
+  conda activate immuneml_env/
+
+4. Install additional R dependencies from the script provided `here <https://drive.google.com/file/d/1C0m7bjG7OKfWNVQsgYkE-nXCdvD7mO08/view?usp=sharing>`_
+
+.. code-block:: console
+
+  sh install_immuneML_R_dependencies.sh
+
+5. Install basic immuneML including Python and R dependencies from GitHub using pip:
+
+.. code-block:: console
+
+  pip install git+https://github.com/uio-bmi/immuneML#egg=immuneML[R_plots]
+
+Alternatively, if you want to install immuneML including optional extras (:code:`DeepRC`, :code:`TCRDist`), use:
 
 .. code-block:: console
 
   pip install git+https://github.com/uio-bmi/immuneML#egg=immuneML[R_plots,DeepRC,TCRDist]
 
-Installing DeepRC and TCRDist dependencies is necessary to use the :ref:`DeepRC` and :ref:`TCRDISTClassifier` ML methods. 
-It is also possible to specify a subset of extras, for example, include only :code:`R_plots`.
+Installing DeepRC and TCRDist dependencies is necessary to use the :ref:`DeepRC` and :ref:`TCRDISTClassifier` ML methods.
 
 6. To validate the installation, run:
 
@@ -98,8 +168,11 @@ To update the existing installation (obtained as described before):
 
   pip install git+https://github.com/uio-bmi/immuneML
 
-Alternatively, if you want to install immuneML including all R plots, use:
+Alternatively, if you want to install immuneML including optional dependencies (:code:`R_plots`, :code:`DeepRC`, :code:`TCRDist`), use:
 
 .. code-block:: console
 
-  pip install git+https://github.com/uio-bmi/immuneML#egg=immuneML[R_plots]
+  pip install git+https://github.com/uio-bmi/immuneML#egg=immuneML[R_plots,DeepRC,TCRDist]
+
+Note: when including R_plots, make sure that R dependencies were installed using the steps described in :ref:`Install immuneML with R dependencies`
+steps 2 - 4.

--- a/docs/source/installation/install_with_package_manager.rst
+++ b/docs/source/installation/install_with_package_manager.rst
@@ -29,7 +29,7 @@ Install immuneML without R dependencies
 
   conda activate immuneml_env/
 
-5. Install basic immuneML including Python dependencies from GitHub using pip:
+4. Install basic immuneML including Python dependencies from GitHub using pip:
 
 .. code-block:: console
 
@@ -43,8 +43,9 @@ Alternatively, if you want to install immuneML including optional extras (:code:
 
 Installing DeepRC and TCRDist dependencies is necessary to use the :ref:`DeepRC` and :ref:`TCRDISTClassifier` ML methods.
 It is also possible to specify a subset of extras, for example, include only :code:`DeepRC`.
+Mac users trying to install the :code:`TCRDist` extra, please see :ref:`this FAQ<When installing immuneML, I get an error (RuntimeError: autoreconf -fi failed), what should I do?>`.
 
-6. To validate the installation, run:
+5. To validate the installation, run:
 
 .. code-block:: console
 
@@ -113,6 +114,7 @@ Alternatively, if you want to install immuneML including optional extras (:code:
   pip install git+https://github.com/uio-bmi/immuneML#egg=immuneML[R_plots,DeepRC,TCRDist]
 
 Installing DeepRC and TCRDist dependencies is necessary to use the :ref:`DeepRC` and :ref:`TCRDISTClassifier` ML methods.
+Mac users trying to install the :code:`TCRDist` extra, please see :ref:`this FAQ<When installing immuneML, I get an error (RuntimeError: autoreconf -fi failed), what should I do?>`.
 
 6. To validate the installation, run:
 
@@ -174,5 +176,5 @@ Alternatively, if you want to install immuneML including optional dependencies (
 
   pip install git+https://github.com/uio-bmi/immuneML#egg=immuneML[R_plots,DeepRC,TCRDist]
 
-Note: when including R_plots, make sure that R dependencies were installed using the steps described in :ref:`Install immuneML with R dependencies`
-steps 2 - 4.
+Note: when including R_plots, make sure that R dependencies were installed using the steps described in :ref:`Install immuneML with R dependencies` steps 2 - 4.
+Mac users trying to install the :code:`TCRDist` extra, please see :ref:`this FAQ<When installing immuneML, I get an error (RuntimeError: autoreconf -fi failed), what should I do?>`.

--- a/docs/source/installation/install_with_package_manager.rst
+++ b/docs/source/installation/install_with_package_manager.rst
@@ -43,7 +43,6 @@ Alternatively, if you want to install immuneML including optional extras (:code:
 
 Installing DeepRC and TCRDist dependencies is necessary to use the :ref:`DeepRC` and :ref:`TCRDISTClassifier` ML methods.
 It is also possible to specify a subset of extras, for example, include only :code:`DeepRC`.
-Mac users trying to install the :code:`TCRDist` extra, please see :ref:`this FAQ<When installing immuneML, I get an error (RuntimeError: autoreconf -fi failed), what should I do?>`.
 
 5. To validate the installation, run:
 
@@ -114,7 +113,6 @@ Alternatively, if you want to install immuneML including optional extras (:code:
   pip install git+https://github.com/uio-bmi/immuneML#egg=immuneML[R_plots,DeepRC,TCRDist]
 
 Installing DeepRC and TCRDist dependencies is necessary to use the :ref:`DeepRC` and :ref:`TCRDISTClassifier` ML methods.
-Mac users trying to install the :code:`TCRDist` extra, please see :ref:`this FAQ<When installing immuneML, I get an error (RuntimeError: autoreconf -fi failed), what should I do?>`.
 
 6. To validate the installation, run:
 
@@ -177,4 +175,3 @@ Alternatively, if you want to install immuneML including optional dependencies (
   pip install git+https://github.com/uio-bmi/immuneML#egg=immuneML[R_plots,DeepRC,TCRDist]
 
 Note: when including R_plots, make sure that R dependencies were installed using the steps described in :ref:`Install immuneML with R dependencies` steps 2 - 4.
-Mac users trying to install the :code:`TCRDist` extra, please see :ref:`this FAQ<When installing immuneML, I get an error (RuntimeError: autoreconf -fi failed), what should I do?>`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ rpy2
 pytest==4.3.1
 pandas==0.24.2
 scikit-learn>=0.22.2.post1
-gensim==3.8.1
+gensim==3.8.3
 matplotlib==3.1.1
 editdistance==0.5.3
 dask[complete]
@@ -23,5 +23,6 @@ git+https://github.com/ml-jku/DeepRC@fec4b4f4b2cd70e00e8de83da169560dec73a419
 git+https://github.com/widmi/widis-lstm-tools
 git+https://github.com/kmayerb/tcrdist2.git
 fishersapi
+parasail==1.2
 tcrdist3>=0.1.6
 matplotlib-venn>=0.11.6

--- a/setup.py
+++ b/setup.py
@@ -14,11 +14,11 @@ setup(
     url="https://github.com/uio-bmi/ImmuneML",
     install_requires=["pytest>=4.3.1", "pandas>=1.1.1", "scikit-learn>=0.22.2.post1", "gensim==3.8.1", "matplotlib>=3.1.1", "editdistance==0.5.3",
                       "dask[complete]", "regex", "tzlocal", "airr==1.2.1", "pystache==0.5.4", "torch==1.5.1", "numpy>=1.18.2", "h5py>=2.9.0",
-                      "dill>=0.3.0", "tqdm>=0.24.2", "logomaker>=0.8", "plotly>=4.8.2", "fishersapi", "requests>=2.21.0",
-                      "deeprc@git+https://github.com/ml-jku/DeepRC@fec4b4f4b2cd70e00e8de83da169560dec73a419", "matplotlib-venn>=0.11.6",
-                      "widis-lstm-tools@git+https://github.com/widmi/widis-lstm-tools", "tcrdist3>=0.1.6"],
+                      "dill>=0.3.0", "tqdm>=0.24.2", "logomaker>=0.8", "plotly>=4.8.2", "fishersapi", "requests>=2.21.0", "matplotlib-venn>=0.11.6"],
     extras_require={
-        "R_plots":  ["rpy2"]
+        "R_plots":  ["rpy2"],
+        "DeepRC":  ["widis-lstm-tools@git+https://github.com/widmi/widis-lstm-tools", "deeprc@git+https://github.com/ml-jku/DeepRC@fec4b4f4b2cd70e00e8de83da169560dec73a419"],
+        "TCRDist": ["tcrdist3>=0.1.6"],
     },
     classifiers=[
         "Programming Language :: Python :: 3"

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     extras_require={
         "R_plots":  ["rpy2"],
         "DeepRC":  ["widis-lstm-tools@git+https://github.com/widmi/widis-lstm-tools", "deeprc@git+https://github.com/ml-jku/DeepRC@fec4b4f4b2cd70e00e8de83da169560dec73a419"],
-        "TCRDist": ["tcrdist3>=0.1.6"],
+        "TCRDist": ["parasail=1.2", "tcrdist3>=0.1.6"],
     },
     classifiers=[
         "Programming Language :: Python :: 3"

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     extras_require={
         "R_plots":  ["rpy2"],
         "DeepRC":  ["widis-lstm-tools@git+https://github.com/widmi/widis-lstm-tools", "deeprc@git+https://github.com/ml-jku/DeepRC@fec4b4f4b2cd70e00e8de83da169560dec73a419"],
-        "TCRDist": ["parasail=1.2", "tcrdist3>=0.1.6"],
+        "TCRDist": ["parasail==1.2", "tcrdist3>=0.1.6"],
     },
     classifiers=[
         "Programming Language :: Python :: 3"

--- a/source/encodings/deeprc/DeepRCEncoder.py
+++ b/source/encodings/deeprc/DeepRCEncoder.py
@@ -11,7 +11,7 @@ from source.util.PathBuilder import PathBuilder
 
 class DeepRCEncoder(DatasetEncoder):
     """
-    DeepRCEncoder should be used in combination with the DeepRC ML method (:py:mod:`source.ml_methods.DeepRC.DeepRC`).
+    DeepRCEncoder should be used in combination with the DeepRC ML method (:ref:`DeepRC`).
     This encoder writes the data in a RepertoireDataset to .tsv files.
     For each repertoire, one .tsv file is created containing the amino acid sequences and the counts.
     Additionally, one metadata .tsv file is created, which describes the subset of repertoires that is encoded by

--- a/source/ml_methods/DeepRC.py
+++ b/source/ml_methods/DeepRC.py
@@ -26,7 +26,7 @@ from source.util.PathBuilder import PathBuilder
 class DeepRC(MLMethod):
     """
     This classifier uses the DeepRC method for repertoire classification. The DeepRC ML method should be used in combination
-    with the DeepRCEncoder (:py:mod:`source.encodings.deeprc.DeepRCEncoder.DeepRCEncoder`).
+    with the DeepRC encoder.
 
 
     Reference:


### PR DESCRIPTION
Addresses this trello card: https://trello.com/c/gqK6DsfW/312-look-into-whether-it-could-be-easy-to-separate-tcrdist-and-deeprc-from-the-core-installation-procedure-to-have-them-as-add-ons-m

- DeepRC and TCRDist are now by default not installed, but can be added. 
- Installation documentation has been updated 
- Installation docs is also now written to a version with and without R, to make it clearer
- Even more proof that this separation of dependencies is necessary: I encountered a bug when installing the TCRDist dependencies on Mac. In other words, installing the current version of immuneML did not work without errors! But now that TCRDist is optional, that bug only occurs when explicitly adding TCRDist. I tried to find a fix for this (automatically installing other packages), but did not manage to find a good solution. In a way, it is not our responsibility. In the FAQ I added a link to the github issue where someone proposes a hacky workaround, in case they are super dedicated to make it work...