### PR TITLE
super small fix: dont overwrite metadata column mapping if not given in Galaxy

### DIFF
--- a/immuneML/api/galaxy/build_dataset_yaml.py
+++ b/immuneML/api/galaxy/build_dataset_yaml.py
@@ -50,8 +50,8 @@ def build_specs(args):
         if paired:
             specs["definitions"]["datasets"][args.dataset_name]["params"]["receptor_chains"] = args.receptor_chains
 
-        specs["definitions"]["datasets"][args.dataset_name]["params"]["metadata_column_mapping"] = build_metadata_column_mapping(
-            args.metadata_columns)
+        if args.metadata_columns != "":
+            specs["definitions"]["datasets"][args.dataset_name]["params"]["metadata_column_mapping"] = build_metadata_column_mapping(args.metadata_columns)
 
     return specs
 


### PR DESCRIPTION
if no metadata mapping is given, use the default one (e.g, VDJdb format)