### PR TITLE
Improve readability of ExploratoryAnalysis HTML

### DIFF
--- a/immuneML/presentation/html/ExploratoryAnalysisHTMLBuilder.py
+++ b/immuneML/presentation/html/ExploratoryAnalysisHTMLBuilder.py
@@ -47,15 +47,20 @@ class ExploratoryAnalysisHTMLBuilder:
                 "dataset_type": StringHelper.camel_case_to_word_string(type(analysis.dataset).__name__),
                 "example_count": analysis.dataset.get_example_count(),
                 "dataset_size": f"{analysis.dataset.get_example_count()} {type(analysis.dataset).__name__.replace('Dataset', 's').lower()}",
-                "show_labels": analysis.label_config is not None,
+                "show_labels": analysis.label_config is not None and len(analysis.label_config.get_labels_by_name()) > 0,
                 "labels": [{"name": label.name, "values": str(label.values)[1:-1]}
                            for label in analysis.label_config.get_label_objects()] if analysis.label_config else None,
+                "encoding_key": analysis.encoder.name if analysis.encoder is not None else None,
                 "encoding_name": StringHelper.camel_case_to_word_string(type(analysis.encoder).__name__) if analysis.encoder is not None
                 else None,
-                "encoding_params": vars(analysis.encoder) if analysis.encoder is not None else None,
+                "encoding_params": [{"param_name": key, "param_value": value} for key, value in vars(analysis.encoder).items()] if analysis.encoder is not None else None,
                 "show_encoding": analysis.encoder is not None,
                 "report": Util.to_dict_recursive(analysis.report_result, base_path)
             } for name, analysis in state.exploratory_analysis_units.items()]
         }
+
+        for analysis in html_map["analyses"]:
+            analysis["show_tables"] = len(analysis["report"]["output_tables"]) > 0
+
 
         return html_map

--- a/immuneML/presentation/html/Util.py
+++ b/immuneML/presentation/html/Util.py
@@ -3,6 +3,7 @@ import os
 import shutil
 from enum import Enum
 from pathlib import Path
+import numpy as np
 
 from immuneML.reports.ReportOutput import ReportOutput
 from immuneML.reports.ReportResult import ReportResult
@@ -33,10 +34,20 @@ class Util:
                 attribute_name: Util.to_dict_recursive(vars_obj[attribute_name], base_path) for attribute_name in vars_obj.keys()
             }
             if isinstance(obj, ReportOutput):
-                if any([ext == getattr(obj, "path", "").suffix for ext in ['.svg', '.jpg', '.png']]):
-                    result['is_embed'] = False
+                path = getattr(obj, "path")
+
+                if path is not None:
+                    result['is_download_link'] = True
+                    result['download_link'] = os.path.relpath(path=getattr(obj, "path"), start=base_path)
+                    result['file_name'] = getattr(obj, "name")
+
+                    if any([ext == path.suffix for ext in ['.svg', '.jpg', '.png']]):
+                        result['is_embed'] = False
+                    else:
+                        result['is_embed'] = True
                 else:
-                    result['is_embed'] = True
+                    result['is_download_link'] = False
+
             return result
 
     @staticmethod

--- a/immuneML/presentation/html/templates/ExploratoryAnalysis.html
+++ b/immuneML/presentation/html/templates/ExploratoryAnalysis.html
@@ -43,19 +43,28 @@
                 <div class="col-container">
                     <div>
                         {{#show_encoding}}
-                        <h3>Encoding</h3>
+                        <h3>Encoding {{encoding_key}}</h3>
+                        <h4>{{encoding_name}}</h4>
+
                         <div class="table-container">
                             <table>
-                            <tr>
-                                <td><b>Encoding Name</b></td>
-                                <td>{{encoding_name}}</td>
-                            </tr>
-                            <tr>
-                                <td><b>Encoding parameters</b></td>
-                                <td>{{encoding_params}}</td>
-                            </tr>
-                        </table>
+                                <thead>
+                                    <tr>
+                                        <th>Parameter</th>
+                                        <th>Value</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {{#encoding_params}}
+                                    <tr>
+                                        <td>{{param_name}}</td>
+                                        <td>{{param_value}}</td>
+                                    </tr>
+                                    {{/encoding_params}}
+                                </tbody>
+                            </table>
                         </div>
+
                         {{/show_encoding}}
                         {{#show_labels}}
                         <h3>Analysis labels</h3>
@@ -81,18 +90,32 @@
                     </div>
                 </div>
                 {{#report}}
+                <h3>Report {{name}}</h3>
                 <div>
                     {{#output_figures}}
                     <div class="center padded">
+                        {{#name}}<p>{{name}}</p>{{/name}}
                         {{#is_embed}}
                         <embed src="{{path}}">
                         {{/is_embed}}
                         {{^is_embed}}
                         <img src="{{path}}">
                         {{/is_embed}}
-                        {{#name}}<p>{{name}}</p>{{/name}}
                     </div>
                     {{/output_figures}}
+
+                    {{#show_tables}}
+                    Downloadable tables:
+                    {{#output_tables}}
+                    <div>
+                        <ul>
+                        {{#is_download_link}}
+                        <li><a href="{{download_link}}" download>{{file_name}}</a></li>
+                        {{/is_download_link}}
+                        </ul>
+                    </div>
+                    {{/output_tables}}
+                    {{/show_tables}}
                 </div>
                 {{/report}}
             </div>

--- a/immuneML/reports/ReportResult.py
+++ b/immuneML/reports/ReportResult.py
@@ -9,5 +9,3 @@ class ReportResult:
     name: str = None
     output_figures: List[ReportOutput] = field(default_factory=lambda: [])
     output_tables: List[ReportOutput] = field(default_factory=lambda: [])
-    output_text: List[ReportOutput] = field(default_factory=lambda: [])
-    other_output: List[ReportOutput] = field(default_factory=lambda: [])

--- a/immuneML/reports/encoding_reports/Matches.py
+++ b/immuneML/reports/encoding_reports/Matches.py
@@ -102,7 +102,7 @@ class Matches(EncodingReport):
             elif self.dataset.encoded_data.encoding == "MatchedRegexEncoder":
                 self._write_paired_regex_matches_for_repertoire(self.dataset.encoded_data.examples[i], file_path)
 
-            report_outputs.append(ReportOutput(file_path, f"example {self.dataset.encoded_data.example_ids[i]} paired matches"))
+            report_outputs.append(ReportOutput(file_path, f"Example {self.dataset.encoded_data.example_ids[i]} paired matches"))
 
         return report_outputs
 
@@ -171,7 +171,7 @@ class Matches(EncodingReport):
         results_path = self.result_path / "repertoire_sizes.csv"
         results_df.to_csv(results_path, index=False)
 
-        return ReportOutput(results_path, "repertoire sizes")
+        return ReportOutput(results_path, "Repertoire sizes")
 
     def _write_receptor_info(self, receptor_info_path) -> List[ReportOutput]:
         PathBuilder.build(receptor_info_path)
@@ -209,7 +209,11 @@ class Matches(EncodingReport):
         unique_receptors_path = receptor_info_path / "unique_receptors.csv"
         unique_receptors.to_csv(unique_receptors_path, index=False)
 
-        return [ReportOutput(p) for p in [receptors_path, receptor_chains_path, unique_receptors_path, unique_chain1_path, unique_chain2_path]]
+        return [ReportOutput(path=path, name=name) for path, name in [(receptors_path, "All receptors info"),
+                                                                      (receptor_chains_path, "All receptor chains info"),
+                                                                      (unique_receptors_path, "Unique receptors info"),
+                                                                      (unique_chain1_path, "Unique chain 1 info"),
+                                                                      (unique_chain2_path, "Unique chain 2 info")]]
 
     def _write_sequence_info(self, sequence_info_path) -> List[ReportOutput]:
         PathBuilder.build(sequence_info_path)
@@ -222,7 +226,7 @@ class Matches(EncodingReport):
         unique_chains_path = sequence_info_path / "unique_chains.csv"
         unique_chains.to_csv(unique_chains_path, index=False)
 
-        return [ReportOutput(p) for p in [chains_path, unique_chains_path]]
+        return [ReportOutput(path=path, name=name) for path, name in [(chains_path, "All chains info"), (unique_chains_path, "Unique chains info")]]
 
     def check_prerequisites(self):
         if self.dataset.encoded_data is None or self.dataset.encoded_data.examples is None:

--- a/test/presentation/html/test_ExploratoryAnalysisHTMLBuilder.py
+++ b/test/presentation/html/test_ExploratoryAnalysisHTMLBuilder.py
@@ -3,12 +3,15 @@ import shutil
 from unittest import TestCase
 
 from immuneML.data_model.dataset.RepertoireDataset import RepertoireDataset
+from immuneML.encodings.EncoderParams import EncoderParams
+from immuneML.encodings.reference_encoding.MatchedSequencesEncoder import MatchedSequencesEncoder
 from immuneML.environment.EnvironmentSettings import EnvironmentSettings
 from immuneML.environment.Label import Label
 from immuneML.environment.LabelConfiguration import LabelConfiguration
 from immuneML.preprocessing.SubjectRepertoireCollector import SubjectRepertoireCollector
 from immuneML.presentation.html.ExploratoryAnalysisHTMLBuilder import ExploratoryAnalysisHTMLBuilder
 from immuneML.reports.data_reports.SequenceLengthDistribution import SequenceLengthDistribution
+from immuneML.reports.encoding_reports.Matches import Matches
 from immuneML.util.PathBuilder import PathBuilder
 from immuneML.util.RepertoireBuilder import RepertoireBuilder
 from immuneML.workflows.instructions.exploratory_analysis.ExploratoryAnalysisInstruction import ExploratoryAnalysisInstruction
@@ -42,14 +45,29 @@ class TestExploratoryAnalysisHTMLBuilder(TestCase):
         with open(path / "refs.tsv", "w") as file:
             file.writelines(file_content)
 
-        refs_dict = {"path": path / "refs.tsv", "format": "VDJdb"}
+        refs_dict = {"params": {"path": path / "refs.tsv", "region_type": "FULL_SEQUENCE", "paired": False}, "format": "VDJdb"}
 
         preproc_sequence = [SubjectRepertoireCollector()]
+
+        encoder = MatchedSequencesEncoder.build_object(dataset, **{
+            "reference": refs_dict,
+            "max_edit_distance": 0
+        }, name="test_encoding")
+
+        encoded = encoder.encode(dataset, EncoderParams(
+            result_path=path,
+            label_config=label_config,
+            filename="dataset.csv"
+        ))
 
         units = {"named_analysis_1": ExploratoryAnalysisUnit(dataset=dataset, report=SequenceLengthDistribution(), number_of_processes=16),
                  "named_analysis_2": ExploratoryAnalysisUnit(dataset=dataset, report=SequenceLengthDistribution(),
                                                              preprocessing_sequence=preproc_sequence,
-                                                             label_config=LabelConfiguration(labels=[Label(name="test_label", values=["val1", "val2"], positive_class="val1")]))}
+                                                             label_config=LabelConfiguration(labels=[Label(name="test_label", values=["val1", "val2"], positive_class="val1")])),
+                 "named_analysis_3": ExploratoryAnalysisUnit(dataset=encoded, report=Matches(dataset=encoded, name="test_report_name"),
+                                                             preprocessing_sequence=preproc_sequence, encoder=encoder,
+                                                             label_config=LabelConfiguration())
+                 }
 
         process = ExploratoryAnalysisInstruction(units)
         res = process.run(path / "results/")


### PR DESCRIPTION
- List downloadable tables
- Put encoding params in a table instead of printing the dict

Also removes output_text and other_output lists from ReportResult since they are not being used in any report so far