### PR TITLE
Repertoire filenames instead of UUID

### DIFF
--- a/immuneML/IO/dataset_export/AIRRExporter.py
+++ b/immuneML/IO/dataset_export/AIRRExporter.py
@@ -44,7 +44,7 @@ class AIRRExporter(DataExporter):
             for index, repertoire in enumerate(dataset.repertoires):
                 df = AIRRExporter._repertoire_to_dataframe(repertoire, region_type)
                 df = AIRRExporter._postprocess_dataframe(df)
-                output_file = repertoire_path / f"{repertoire.identifier}.tsv"
+                output_file = repertoire_path / f"{repertoire.data_filename.stem}.tsv"
                 airr.dump_rearrangement(df, str(output_file))
 
             AIRRExporter.export_updated_metadata(dataset, path, repertoire_folder)
@@ -84,7 +84,7 @@ class AIRRExporter(DataExporter):
     def export_updated_metadata(dataset: RepertoireDataset, result_path: Path, repertoire_folder: str):
         df = pd.read_csv(dataset.metadata_file, comment=Constants.COMMENT_SIGN)
         identifiers = df["repertoire_identifier"].values.tolist() if "repertoire_identifier" in df.columns else dataset.get_example_ids()
-        df["filename"] = [str(Path(repertoire_folder) / f"{item}.tsv") for item in identifiers]
+        df["filename"] =[str(Path(repertoire_folder) / f"{repertoire.data_filename.stem}.tsv") for repertoire in dataset.get_data()]
         df.to_csv(result_path / "metadata.csv", index=False)
 
     @staticmethod

--- a/immuneML/preprocessing/filters/CountPerSequenceFilter.py
+++ b/immuneML/preprocessing/filters/CountPerSequenceFilter.py
@@ -82,7 +82,7 @@ class CountPerSequenceFilter(Filter):
             indices_to_keep[np.logical_not(not_none_indices)] = True
             np.greater_equal(counts, params["low_count_limit"], out=indices_to_keep, where=not_none_indices)
 
-        processed_repertoire = Repertoire.build_like(repertoire, indices_to_keep, params["result_path"])
+        processed_repertoire = Repertoire.build_like(repertoire, indices_to_keep, params["result_path"], filename_base=f"{repertoire.data_filename.stem}_filtered")
 
         return processed_repertoire
 

--- a/immuneML/preprocessing/filters/DuplicateSequenceFilter.py
+++ b/immuneML/preprocessing/filters/DuplicateSequenceFilter.py
@@ -153,7 +153,8 @@ class DuplicateSequenceFilter(Filter):
                                                 custom_lists={key: list(no_duplicates[key]) for key in custom_lists},
                                                 sequence_identifiers=list(no_duplicates["sequence_identifiers"]),
                                                 metadata=copy.deepcopy(repertoire.metadata),
-                                                path=params["result_path"])
+                                                path=params["result_path"],
+                                                filename_base=f"{repertoire.data_filename.stem}_filtered")
 
         return processed_repertoire
 

--- a/immuneML/util/ImportHelper.py
+++ b/immuneML/util/ImportHelper.py
@@ -128,13 +128,17 @@ class ImportHelper:
         try:
             alternative_load_func = getattr(import_class, "alternative_load_func", None)
 
-            dataframe = ImportHelper.load_sequence_dataframe(params.path / f"{metadata_row['filename']}", params, alternative_load_func)
+            filename = params.path / f"{metadata_row['filename']}"
+
+            dataframe = ImportHelper.load_sequence_dataframe(filename, params, alternative_load_func)
             dataframe = import_class.preprocess_dataframe(dataframe, params)
             sequence_lists = {field: dataframe[field].values.tolist() for field in Repertoire.FIELDS if field in dataframe.columns}
             sequence_lists["custom_lists"] = {field: dataframe[field].values.tolist()
                                               for field in list(set(dataframe.columns) - set(Repertoire.FIELDS))}
 
-            repertoire_inputs = {**{"metadata": metadata_row.to_dict(), "path": params.result_path / "repertoires/"}, **sequence_lists}
+            repertoire_inputs = {**{"metadata": metadata_row.to_dict(),
+                                    "path": params.result_path / "repertoires/",
+                                    "filename_base": filename.stem}, **sequence_lists}
             repertoire = Repertoire.build(**repertoire_inputs)
 
             return repertoire

--- a/immuneML/util/RepertoireBuilder.py
+++ b/immuneML/util/RepertoireBuilder.py
@@ -54,7 +54,7 @@ class RepertoireBuilder:
             repertoire = Repertoire.build_from_sequence_objects(rep_sequences, rep_path, metadata)
             repertoires.append(repertoire)
 
-        df = pd.DataFrame({**{"filename": [f"{repertoire.identifier}_data.npy" for repertoire in repertoires], "subject_id": subject_ids,
+        df = pd.DataFrame({**{"filename": [f"{repertoire.identifier}.npy" for repertoire in repertoires], "subject_id": subject_ids,
                               "repertoire_identifier": [repertoire.identifier for repertoire in repertoires]},
                            **(labels if labels is not None else {})})
         df.to_csv(path / "metadata.csv", index=False)


### PR DESCRIPTION
re-use original repertoire filenames for output filenames (Pickle/AIRR) instead of UUID (but keep UUID as identifier)

The suffix '_data' has been removed from the internal npy files, so that this filename can be used as a base for determining the output filename. 
Filtered repertoires (which may contain slightly different content) will receive the suffix '_filtered' to their original name