### PR TITLE
column_mapping_synonyms

### DIFF
--- a/immuneML/IO/dataset_import/AIRRImport.py
+++ b/immuneML/IO/dataset_import/AIRRImport.py
@@ -85,6 +85,11 @@ class AIRRImport(DataImport):
         they are present in the AIRR file, or using alternative column names).
         Valid immuneML fields that can be specified here are defined by Repertoire.FIELDS
 
+        column_mapping_synonyms (dict): This is a column mapping that can be used if a column could have alternative names.
+        The formatting is the same as column_mapping. If some columns specified in column_mapping are not found in the file,
+        the columns specified in column_mapping_synonyms are instead attempted to be loaded.
+        For AIRR format, there is no default column_mapping_synonyms.
+
         metadata_column_mapping (dict): Specifies metadata for Sequence- and ReceptorDatasets. This should specify a mapping similar
         to column_mapping where keys are AIRR column names and values are the names that are internally used in immuneML
         as metadata fields. These metadata fields can be used as prediction labels for Sequence- and ReceptorDatasets.

--- a/immuneML/IO/dataset_import/DatasetImportParams.py
+++ b/immuneML/IO/dataset_import/DatasetImportParams.py
@@ -16,6 +16,7 @@ class DatasetImportParams:
     columns_to_load: list = None
     separator: str = None
     column_mapping: dict = None
+    column_mapping_synonyms: dict = None
     region_type: RegionType = None
     import_productive: bool = None
     import_unproductive: bool = None

--- a/immuneML/IO/dataset_import/GenericImport.py
+++ b/immuneML/IO/dataset_import/GenericImport.py
@@ -76,6 +76,11 @@ class GenericImport(DataImport):
                 file_column_j_genes: j_genes
                 file_column_frequencies: counts
 
+        column_mapping_synonyms (dict): This is a column mapping that can be used if a column could have alternative names.
+        The formatting is the same as column_mapping. If some columns specified in column_mapping are not found in the file,
+        the columns specified in column_mapping_synonyms are instead attempted to be loaded.
+        For Generic import, there is no default column_mapping_synonyms.
+
         metadata_column_mapping (dict): Optional; specifies metadata for Sequence- and ReceptorDatasets. This is a column
         mapping that is formatted similarly to column_mapping, but here the values are the names that immuneML internally
         uses as metadata fields. These fields can subsequently be used as labels in instructions (for example labels

--- a/immuneML/IO/dataset_import/IGoRImport.py
+++ b/immuneML/IO/dataset_import/IGoRImport.py
@@ -68,6 +68,11 @@ class IGoRImport(DataImport):
         they are present in the IGoR file, or using alternative column names).
         Valid immuneML fields that can be specified here are defined by Repertoire.FIELDS
 
+        column_mapping_synonyms (dict): This is a column mapping that can be used if a column could have alternative names.
+        The formatting is the same as column_mapping. If some columns specified in column_mapping are not found in the file,
+        the columns specified in column_mapping_synonyms are instead attempted to be loaded.
+        For IGoR format, there is no default column_mapping_synonyms.
+
         metadata_column_mapping (dict): Specifies metadata for SequenceDatasets. This should specify a mapping similar
         to column_mapping where keys are IGoR column names and values are the names that are internally used in immuneML
         as metadata fields. These metadata fields can be used as prediction labels for SequenceDatasets.

--- a/immuneML/IO/dataset_import/IReceptorImport.py
+++ b/immuneML/IO/dataset_import/IReceptorImport.py
@@ -94,6 +94,11 @@ class IReceptorImport(DataImport):
         they are present in the AIRR file, or using alternative column names).
         Valid immuneML fields that can be specified here are defined by Repertoire.FIELDS
 
+        column_mapping_synonyms (dict): This is a column mapping that can be used if a column could have alternative names.
+        The formatting is the same as column_mapping. If some columns specified in column_mapping are not found in the file,
+        the columns specified in column_mapping_synonyms are instead attempted to be loaded.
+        For AIRR format, there is no default column_mapping_synonyms.
+
         metadata_column_mapping (dict): Specifies metadata for Sequence- and ReceptorDatasets. This should specify a mapping similar
         to column_mapping where keys are AIRR column names and values are the names that are internally used in immuneML
         as metadata fields. These metadata fields can be used as prediction labels for Sequence- and ReceptorDatasets.

--- a/immuneML/IO/dataset_import/ImmunoSEQRearrangementImport.py
+++ b/immuneML/IO/dataset_import/ImmunoSEQRearrangementImport.py
@@ -84,13 +84,24 @@ class ImmunoSEQRearrangementImport(DataImport):
         they are present in the file, or using alternative column names).
         Valid immuneML fields that can be specified here are defined by Repertoire.FIELDS
 
+        column_mapping_synonyms (dict): This is a column mapping that can be used if a column could have alternative names.
+        The formatting is the same as column_mapping. If some columns specified in column_mapping are not found in the file,
+        the columns specified in column_mapping_synonyms are instead attempted to be loaded.
+        For immunoSEQ rearrangement-level files, this is by default set to:
+
+        .. indent with spaces
+        .. code-block:: yaml
+
+                v_resolved: v_alleles
+                j_resolved: j_alleles
+
         columns_to_load (list): Specifies which subset of columns must be loaded from the file. By default, this is:
         [rearrangement, v_family, v_gene, v_allele, j_family, j_gene, j_allele, amino_acid, templates, frame_type, locus]
 
         metadata_column_mapping (dict): Specifies metadata for SequenceDatasets. This should specify a mapping similar
         to column_mapping where keys are immunoSEQ column names and values are the names that are internally used in immuneML
         as metadata fields. These metadata fields can be used as prediction labels for SequenceDatasets.
-        For immunoSEQ .tsv files, there is no default metadata_column_mapping.
+        For immunoSEQ rearrangement .tsv files, there is no default metadata_column_mapping.
         For setting RepertoireDataset metadata, metadata_column_mapping is ignored, see metadata_file instead.
 
         separator (str): Column separator, for ImmunoSEQ files this is by default "\\t".

--- a/immuneML/IO/dataset_import/ImmunoSEQSampleImport.py
+++ b/immuneML/IO/dataset_import/ImmunoSEQSampleImport.py
@@ -82,13 +82,18 @@ class ImmunoSEQSampleImport(DataImport):
         they are present in the file, or using alternative column names).
         Valid immuneML fields that can be specified here are defined by Repertoire.FIELDS
 
+        column_mapping_synonyms (dict): This is a column mapping that can be used if a column could have alternative names.
+        The formatting is the same as column_mapping. If some columns specified in column_mapping are not found in the file,
+        the columns specified in column_mapping_synonyms are instead attempted to be loaded.
+        For immunoSEQ sample .tsv files, there is no default column_mapping_synonyms.
+
         columns_to_load (list): Specifies which subset of columns must be loaded from the file. By default, this is:
         [nucleotide, aminoAcid, count (templates/reads), vFamilyName, vGeneName, vGeneAllele, jFamilyName, jGeneName, jGeneAllele, sequenceStatus]; these are the columns from the original file that will be imported
 
         metadata_column_mapping (dict): Specifies metadata for SequenceDatasets. This should specify a mapping similar
         to column_mapping where keys are immunoSEQ column names and values are the names that are internally used in immuneML
         as metadata fields. These metadata fields can be used as prediction labels for SequenceDatasets.
-        For immunoSEQ .tsv files, there is no default metadata_column_mapping.
+        For immunoSEQ sample .tsv files, there is no default metadata_column_mapping.
         For setting RepertoireDataset metadata, metadata_column_mapping is ignored, see metadata_file instead.
 
         separator (str): Column separator, for ImmunoSEQ files this is by default "\\t".

--- a/immuneML/IO/dataset_import/MiXCRImport.py
+++ b/immuneML/IO/dataset_import/MiXCRImport.py
@@ -60,6 +60,11 @@ class MiXCRImport(DataImport):
         they are present in the MiXCR file, or using alternative column names).
         Valid immuneML fields that can be specified here are defined by Repertoire.FIELDS
 
+        column_mapping_synonyms (dict): This is a column mapping that can be used if a column could have alternative names.
+        The formatting is the same as column_mapping. If some columns specified in column_mapping are not found in the file,
+        the columns specified in column_mapping_synonyms are instead attempted to be loaded.
+        For MiXCR format, there is no default column_mapping_synonyms.
+
         columns_to_load (list): Specifies which subset of columns must be loaded from the MiXCR file. By default, this is:
         [cloneCount, allVHitsWithScore, allJHitsWithScore, aaSeqCDR3, nSeqCDR3]
 

--- a/immuneML/IO/dataset_import/SingleLineReceptorImport.py
+++ b/immuneML/IO/dataset_import/SingleLineReceptorImport.py
@@ -65,6 +65,10 @@ class SingleLineReceptorImport(DataImport):
                 clone_id: identifier
                 epitope: epitope # metadata field
 
+        column_mapping_synonyms (dict): This is a column mapping that can be used if a column could have alternative names.
+        The formatting is the same as column_mapping. If some columns specified in column_mapping are not found in the file,
+        the columns specified in column_mapping_synonyms are instead attempted to be loaded.
+
         columns_to_load (list): Optional; specifies which columns to load from the input file. This may be useful if
         the input files contain many unused columns. If no value is specified, all columns are loaded.
 

--- a/immuneML/IO/dataset_import/TenxGenomicsImport.py
+++ b/immuneML/IO/dataset_import/TenxGenomicsImport.py
@@ -80,6 +80,11 @@ class TenxGenomicsImport(DataImport):
         they are present in the 10xGenomics file, or using alternative column names).
         Valid immuneML fields that can be specified here are defined by Repertoire.FIELDS
 
+        column_mapping_synonyms (dict): This is a column mapping that can be used if a column could have alternative names.
+        The formatting is the same as column_mapping. If some columns specified in column_mapping are not found in the file,
+        the columns specified in column_mapping_synonyms are instead attempted to be loaded.
+        For 10xGenomics format, there is no default column_mapping_synonyms.
+
         metadata_column_mapping (dict): Specifies metadata for Sequence- and ReceptorDatasets. This should specify a
         mapping similar to column_mapping where keys are 10xGenomics column names and values are the names that are internally
         used in immuneML as metadata fields. These metadata fields can be used as prediction labels for Sequence-

--- a/immuneML/IO/dataset_import/VDJdbImport.py
+++ b/immuneML/IO/dataset_import/VDJdbImport.py
@@ -73,6 +73,11 @@ class VDJdbImport(DataImport):
         they are present in the VDJdb file, or using alternative column names).
         Valid immuneML fields that can be specified here are defined by Repertoire.FIELDS
 
+        column_mapping_synonyms (dict): This is a column mapping that can be used if a column could have alternative names.
+        The formatting is the same as column_mapping. If some columns specified in column_mapping are not found in the file,
+        the columns specified in column_mapping_synonyms are instead attempted to be loaded.
+        For VDJdb format, there is no default column_mapping_synonyms.
+
         metadata_column_mapping (dict): Specifies metadata for Sequence- and ReceptorDatasets. This should specify
         a mapping where keys are VDJdb column names and values are the names that are internally used in immuneML
         as metadata fields.

--- a/immuneML/config/default_params/datasets/immuno_seq_rearrangement_params.yaml
+++ b/immuneML/config/default_params/datasets/immuno_seq_rearrangement_params.yaml
@@ -20,6 +20,9 @@ column_mapping: # adaptive column names -> immuneML repertoire fields
   j_allele: j_alleles
   templates: counts
   locus: chains
+column_mapping_synonyms: # adaptive column names -> immuneML repertoire fields
+  v_resolved: v_alleles  # alternative columns to use when v_alleles and j_alleles are not present
+  j_resolved: j_alleles
 import_empty_nt_sequences: True # keep sequences even though the nucleotide sequence might be empty
 import_empty_aa_sequences: False # filter out sequences if they don't have sequence_aa set
 organism: human

--- a/immuneML/util/ImportHelper.py
+++ b/immuneML/util/ImportHelper.py
@@ -193,6 +193,7 @@ class ImportHelper:
             usecols = set(params.columns_to_load) if hasattr(params, "columns_to_load") and params.columns_to_load is not None else set()
             usecols = usecols.union(set(params.column_mapping.keys()) if hasattr(params, "column_mapping") and params.column_mapping is not None else set())
             usecols = usecols.union(set(params.column_mapping_synonyms.keys()) if hasattr(params, "column_mapping_synonyms") and params.column_mapping_synonyms is not None else set())
+            usecols = usecols.union(set(params.metadata_column_mapping.keys()) if hasattr(params, "metadata_column_mapping") and params.metadata_column_mapping is not None else set())
         else:
             usecols = None
 

--- a/test/IO/dataset_import/test_ImmunoSEQRearrangementImport.py
+++ b/test/IO/dataset_import/test_ImmunoSEQRearrangementImport.py
@@ -162,9 +162,6 @@ rep1.tsv,TRB,1234a""")
         params["result_path"] = path
         params["metadata_file"] = path / "metadata.csv"
         params["path"] = path
-        params["column_mapping"] = {"v_resolved": "v_alleles", "j_resolved": "j_alleles", "templates": "counts",
-          "rearrangement": "sequences", "amino_acid": "sequence_aas"}
-        params["columns_to_load"] = ["v_resolved", "j_resolved", "templates", "amino_acid", "rearrangement"]
 
         dataset = ImmunoSEQRearrangementImport.import_dataset(params, "alternative")
 


### PR DESCRIPTION
Added 'column_mapping_synonyms' to define alternative names for columns. Formatting is the same as column_mapping and metadata_column_mapping. The behavior remains the same if column_mapping_synonyms is not specified. This allows for automatic import of immunoSEQ rearrangment files of analyzer 3.0.

Initially, columns are mapped as usual. If some immuneML column is missing in the resulting dataframe, but a synonym is present in column_mapping_synonyms, the mapping is applied for that column.

Also moved some functionalities in importhelper into separate functions, and updated usecols when loading a dataframe;
- first attempt usecols = columns_to_load + column_mapping keys + column_mapping_synonyms keys + metadata_column mapping keys
- if this fails, attempt usecols = columns_to_load
- if this fails, load all columns