### PR TITLE
Bugfixes in DistanceEncoder

### DIFF
--- a/immuneML/config/default_params/encodings/distance_params.yaml
+++ b/immuneML/config/default_params/encodings/distance_params.yaml
@@ -1,3 +1,4 @@
 attributes_to_match:
     - sequence_aas
-pool_size: 4
+sequence_batch_size: 1000
+distance_metric: JACCARD

--- a/immuneML/encodings/distance_encoding/DistanceEncoder.py
+++ b/immuneML/encodings/distance_encoding/DistanceEncoder.py
@@ -29,10 +29,14 @@ class DistanceEncoder(DatasetEncoder):
 
         distance_metric (:py:mod:`~immuneML.encodings.distance_encoding.DistanceMetricType`): The metric used to calculate the
         distance between two repertoires. Names of different distance metric types are allowed values in the specification.
+        The default distance metric is JACCARD (inverse Jaccard).
 
-        attributes_to_match: The attributes to consider when determining whether a sequence is present in both repertoires.
+        sequence_batch_size (int): The number of sequences to be processed at once. Increasing this number increases the memory use.
+        The default value is 1000.
+
+        attributes_to_match (list): The attributes to consider when determining whether a sequence is present in both repertoires.
         Only the fields defined under attributes_to_match will be considered, all other fields are ignored.
-        Valid values include any repertoire attribute (sequence, amino acid sequence, V gene etc).
+        Valid values include any repertoire attribute (sequence, amino acid sequence, V gene etc). The default value is ['sequence_aas']
 
     YAML specification:
 
@@ -67,7 +71,7 @@ class DistanceEncoder(DatasetEncoder):
         return self
 
     @staticmethod
-    def _prepare_parameters(distance_metric: str, attributes_to_match: list, sequence_batch_size: int, context: dict = None):
+    def _prepare_parameters(distance_metric: str, attributes_to_match: list, sequence_batch_size: int, context: dict = None, name: str = None):
         valid_metrics = [metric.name for metric in DistanceMetricType]
         ParameterValidator.assert_in_valid_list(distance_metric, valid_metrics, "DistanceEncoder", "distance_metric")
 
@@ -75,7 +79,8 @@ class DistanceEncoder(DatasetEncoder):
             "distance_metric": DistanceMetricType[distance_metric.upper()],
             "attributes_to_match": attributes_to_match,
             "sequence_batch_size": sequence_batch_size,
-            "context": context
+            "context": context,
+            "name": name
         }
 
     @staticmethod

--- a/immuneML/util/DistanceMetrics.py
+++ b/immuneML/util/DistanceMetrics.py
@@ -2,4 +2,4 @@ import numpy as np
 
 
 def jaccard(vector1, vector2, tmp_vector=None):
-    return np.sum(np.logical_and(vector1, vector2, out=tmp_vector)) / np.sum(np.logical_or(vector1, vector2, out=tmp_vector))
+    return 1 - np.sum(np.logical_and(vector1, vector2, out=tmp_vector)) / np.sum(np.logical_or(vector1, vector2, out=tmp_vector))

--- a/test/encodings/distance_encoding/test_distanceEncoder.py
+++ b/test/encodings/distance_encoding/test_distanceEncoder.py
@@ -47,9 +47,9 @@ class TestDistanceEncoder(TestCase):
         self.assertEqual(8, encoded.encoded_data.examples.shape[0])
         self.assertEqual(8, encoded.encoded_data.examples.shape[1])
 
-        self.assertEqual(1, encoded.encoded_data.examples.iloc[0, 0])
-        self.assertEqual(1, encoded.encoded_data.examples.iloc[1, 1])
-        self.assertEqual(1, encoded.encoded_data.examples.iloc[0, 4])
+        self.assertEqual(0, encoded.encoded_data.examples.iloc[0, 0])
+        self.assertEqual(0, encoded.encoded_data.examples.iloc[1, 1])
+        self.assertEqual(0, encoded.encoded_data.examples.iloc[0, 4])
 
         self.assertTrue(np.array_equal([1, 0, 1, 0, 1, 0, 1, 0], encoded.encoded_data.labels["l1"]))
         self.assertTrue(np.array_equal([2, 3, 2, 3, 2, 3, 3, 3], encoded.encoded_data.labels["l2"]))

--- a/test/pairwise_repertoire_comparison/test_pairwiseRepertoireComparison.py
+++ b/test/pairwise_repertoire_comparison/test_pairwiseRepertoireComparison.py
@@ -39,11 +39,11 @@ class TestPairwiseRepertoireComparison(TestCase):
 
         result = comparison.compare_repertoires(dataset, comparison_fn)
 
-        self.assertTrue(np.array_equal(result, np.array([[1., 0., 0., 0.3333333333333333, 0.3333333333333333],
-                                                         [0., 1., 0., 0., 0.5],
-                                                         [0., 0., 1., 0., 0.],
-                                                         [0.3333333333333333, 0., 0., 1., 0.],
-                                                         [0.3333333333333333, 0.5, 0., 0., 1.]])))
+        self.assertTrue(np.array_equal(result, np.array([[0., 1., 1., 0.6666666666666667, 0.6666666666666667],
+                                                         [1., 0., 1., 1., 0.5],
+                                                         [1., 1., 0., 1., 1.],
+                                                         [0.6666666666666667, 1., 1., 0., 1.],
+                                                         [0.6666666666666667, 0.5, 1., 1., 0.]])))
 
         shutil.rmtree(path)
 


### PR DESCRIPTION
- inverse jaccard (distance) instead of jaccard (similarity)
- bugfix: 'name' and 'context' params were not passed to init
- updated default params
- updated docs