### PR TITLE
bugfix: if sequence is string of length 0 but not None, this is also considered 'empty'

### DIFF
--- a/immuneML/util/ImportHelper.py
+++ b/immuneML/util/ImportHelper.py
@@ -247,6 +247,8 @@ class ImportHelper:
             sequence_name = sequence_type.name.lower().replace("_", " ")
 
             if sequence_colname in dataframe.columns:
+                dataframe[sequence_colname].replace({"": Constants.UNKNOWN}, inplace=True)
+
                 n_empty = sum(dataframe[sequence_colname].isnull())
                 if n_empty > 0:
                     dataframe.drop(dataframe.loc[dataframe[sequence_colname].isnull()].index, inplace=True)


### PR DESCRIPTION
This was an edge case that happened in some adaptive files. In the input file a sequence would be length 2 (for example 'TF'). Then after trimming leading and trailing amino acids, the remaining sequence would be length 0. But this happens after applying "standardize none values", meaning some empty sequences are None, and some "". With this fix, "" sequences are also removed upon import. 