### PR TITLE
Bugfixes for Galaxy tools

### DIFF
--- a/immuneML/IO/dataset_export/ImmuneMLExporter.py
+++ b/immuneML/IO/dataset_export/ImmuneMLExporter.py
@@ -58,6 +58,8 @@ class ImmuneMLExporter(DataExporter):
             return str(val.name)
         elif isinstance(val, list) and all(isinstance(v, Path) for v in val):
             return [str(v.name) for v in val]
+        elif isinstance(val, dict):
+            return {inner_key: ImmuneMLExporter._parse_val_for_export(inner_val) for inner_key, inner_val in val.items()}
         else:
             return val
 

--- a/immuneML/api/galaxy/build_yaml_from_arguments.py
+++ b/immuneML/api/galaxy/build_yaml_from_arguments.py
@@ -140,8 +140,7 @@ def discover_dataset_params():
 
     dataset_name = dataset_path.rsplit('.iml_dataset', 1)[0]
 
-    return {"path": dataset_path,
-            "metadata_file": f"{dataset_name}_metadata.csv"}
+    return {"path": dataset_path}
 
 
 def build_labels(labels_str):


### PR DESCRIPTION
- recursively parse dicts in immuneMLExport
- remove metadata file from yaml for simplified interface as it caused errors for receptor datasets