### PR TITLE
Bugfix: label positive_class could not be defined in exploratory analysis

### DIFF
--- a/immuneML/dsl/instruction_parsers/LabelHelper.py
+++ b/immuneML/dsl/instruction_parsers/LabelHelper.py
@@ -1,0 +1,45 @@
+import warnings
+
+from immuneML.data_model.dataset.Dataset import Dataset
+from immuneML.environment.LabelConfiguration import LabelConfiguration
+from immuneML.util.ParameterValidator import ParameterValidator
+
+
+class LabelHelper:
+
+    @staticmethod
+    def check_label_format(labels: list, instruction_name: str, yaml_location: str):
+        ParameterValidator.assert_type_and_value(labels, list, instruction_name, f'{yaml_location}/labels')
+
+        assert all(isinstance(label, str) or isinstance(label, dict) for label in labels), \
+            f"{instruction_name}: labels under {yaml_location} were not defined properly. The list of labels has to either be a list of " \
+            f"label names, or there can be a parameter 'positive_class' defined under the label name, for example:\n" \
+            f"labels: # one label with no positive class (T1D) and one with a positive class (CMV)\n" \
+            f"- T1D\n" \
+            f"- CMV: # when defining a positive class, make sure to use the correct indentation\n" \
+            f"    positive_class: True\n" \
+
+        assert all(len(list(label.keys())) == 1 and isinstance(list(label.values())[0], dict) and 'positive_class' in list(label.values())[0]
+                   and len(list(list(label.values())[0].keys())) == 1 for label in [l for l in labels if isinstance(l, dict)]), \
+            f"{instruction_name}: The only legal parameter under a label name is 'positive_class'. If 'positive_class' is not specified, please remove the colon after the label name. "
+
+    @staticmethod
+    def create_label_config(labels_dict: dict, dataset: Dataset, instruction_name: str, yaml_location: str) -> LabelConfiguration:
+        LabelHelper.check_label_format(labels_dict, instruction_name, yaml_location)
+
+        label_config = LabelConfiguration()
+        for label in labels_dict:
+            label_name = label if isinstance(label, str) else list(label.keys())[0]
+            positive_class = label[label_name]['positive_class'] if isinstance(label, dict) else None
+            if dataset.labels is not None and label_name in dataset.labels:
+                label_values = dataset.labels[label_name]
+            elif hasattr(dataset, "get_metadata"):
+                label_values = list(set(dataset.get_metadata([label_name])[label_name]))
+            else:
+                label_values = []
+                warnings.warn(f"{instruction_name}: for {yaml_location}, label values could not be recovered for label "
+                              f"{label}, using empty list instead. This issue may occur due to improper loading of dataset {dataset.name},"
+                              f"and could cause problems with some encodings.")
+
+            label_config.add_label(label_name, label_values, positive_class=positive_class)
+        return label_config

--- a/immuneML/dsl/instruction_parsers/TrainMLModelParser.py
+++ b/immuneML/dsl/instruction_parsers/TrainMLModelParser.py
@@ -7,6 +7,7 @@ from typing import Tuple
 from immuneML.data_model.dataset.Dataset import Dataset
 from immuneML.dsl.DefaultParamsLoader import DefaultParamsLoader
 from immuneML.dsl.definition_parsers.PreprocessingParser import PreprocessingParser
+from immuneML.dsl.instruction_parsers.LabelHelper import LabelHelper
 from immuneML.dsl.symbol_table.SymbolTable import SymbolTable
 from immuneML.environment.EnvironmentSettings import EnvironmentSettings
 from immuneML.environment.LabelConfiguration import LabelConfiguration
@@ -41,7 +42,7 @@ class TrainMLModelParser:
 
         settings = self._parse_settings(instruction, symbol_table)
         dataset = symbol_table.get(instruction["dataset"])
-        label_config = self._create_label_config(instruction, dataset, key)
+        label_config = LabelHelper.create_label_config(instruction["labels"], dataset, TrainMLModelParser.__name__, key)
         assessment = self._parse_split_config(key, instruction, "assessment", symbol_table, len(settings), label_config)
         selection = self._parse_split_config(key, instruction, "selection", symbol_table, len(settings), label_config)
         assessment, selection = self._update_split_configs(assessment, selection, dataset)
@@ -136,38 +137,6 @@ class TrainMLModelParser:
             path = EnvironmentSettings.default_analysis_path / hashlib.md5(str(instruction).encode()).hexdigest()
 
         return path
-
-    def _check_label_format(self, labels: list, instruction_key: str):
-        ParameterValidator.assert_type_and_value(labels, list, TrainMLModelParser.__name__, f'{instruction_key}/labels')
-        assert all(isinstance(label, str) or isinstance(label, dict) for label in labels), \
-            f"{TrainMLModelParser.__name__}: labels under {instruction_key} were not defined properly. The list of labels has to either be a list of " \
-            f"label names, or there can be a parameter 'positive_class' defined under the label name."
-
-        assert all(len(list(label.keys())) == 1 and isinstance(list(label.values())[0], dict) and 'positive_class' in list(label.values())[0]
-                   and len(list(list(label.values())[0].keys())) == 1 for label in [l for l in labels if isinstance(l, dict)]), \
-            f"{TrainMLModelParser.__name__}: labels that are specified by more than label name, can include only one parameter called 'positive_class'."
-
-    def _create_label_config(self, instruction: dict, dataset: Dataset, instruction_key: str) -> LabelConfiguration:
-        labels = instruction["labels"]
-
-        self._check_label_format(labels, instruction_key)
-
-        label_config = LabelConfiguration()
-        for label in labels:
-            label_name = label if isinstance(label, str) else list(label.keys())[0]
-            positive_class = label[label_name]['positive_class'] if isinstance(label, dict) else None
-            if dataset.labels is not None and label_name in dataset.labels:
-                label_values = dataset.labels[label_name]
-            elif hasattr(dataset, "get_metadata"):
-                label_values = list(set(dataset.get_metadata([label_name])[label_name]))
-            else:
-                label_values = []
-                warnings.warn(f"{TrainMLModelParser.__name__}: for instruction {instruction_key}, label values could not be recovered for label "
-                              f"{label}, using empty list instead.  This could cause problems with some encodings. "
-                              f"If that might be the case, check if the dataset {dataset.name} has been properly loaded.")
-
-            label_config.add_label(label_name, label_values, positive_class=positive_class)
-        return label_config
 
     def _parse_split_config(self, instruction_key, instruction: dict, split_key: str, symbol_table: SymbolTable, settings_count: int,
                             label_config: LabelConfiguration) -> SplitConfig:

--- a/immuneML/environment/Constants.py
+++ b/immuneML/environment/Constants.py
@@ -1,6 +1,6 @@
 class Constants:
 
-    VERSION = "2.0.4"
+    VERSION = "2.0.5"
 
     # encoding constants
     FEATURE_DELIMITER = "///"


### PR DESCRIPTION
I moved the label processing code from TrainMLModelParser to a common LabelHelper class, so it can be used by multiple instructions. The original label processing code in ExploratoryAnalysis was too simple to deal with label positive_class definitions (necessary when testing SequenceAbundance encoder in expl. analysis). Now both TrainMLModelParser and ExploratoryAnalysisParser use LabelHelper to construct their LabelConfiguration. 
