### PR TITLE
docs temporary workaround with old version of setuptools

### DIFF
--- a/docs/source/installation/install_with_package_manager.rst
+++ b/docs/source/installation/install_with_package_manager.rst
@@ -30,7 +30,9 @@ Install immuneML
 
 .. code-block:: console
 
-  conda create --prefix immuneml_env/ python=3.8
+  conda create --prefix immuneml_env/ python=3.8 setuptools=50.3.2
+
+Including :code:`setuptools=50.3.2` is a temporary workaround for the issue described here: :ref:`When running immuneML, I get "ModuleNotFoundError: No module named 'init'"`.
 
 3. Activate the created environment:
 

--- a/docs/source/troubleshooting.rst
+++ b/docs/source/troubleshooting.rst
@@ -16,6 +16,21 @@ Troubleshooting
 Installation issues
 -------------------
 
+During installation of the dependency pystache, I get an error: use_2to3 is invalid.
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The full error reads:
+
+.. code-block:: console
+
+    pystache: using: version '58.0.4' of <module 'setuptools' from 'immuneml_env/lib/python3.8/site-packages/setuptools/__init__.py'>
+    Warning: 'classifiers' should be a list, got type 'tuple'
+    error in pystache setup command: use_2to3 is invalid.
+
+This issue occurs due to an incompatibility between pystache and newer version of setuptools (known to occur with setuptools version 58.0.4 and higher).
+A temporary workaround is to use an older version of setuptools, for example version 50.3.2.
+Updates on fixing the incompatibility in pystache can be followed in this GitHub issue: https://github.com/pypa/pypi-support/issues/1422
+
 When installing all requirements from requirements.txt, there is afterward an error with yaml package (No module named yaml)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -44,6 +59,12 @@ Please note that when using DeepRC from immuneML, a PyTorch distribution that su
 
 Runtime issues
 --------------
+
+When running immuneML, I get "ModuleNotFoundError: No module named 'init'"
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+This issue occurs due to an incompatibility between pystache and newer version of setuptools (known to occur with setuptools version 58.0.4 and higher).
+A temporary workaround is to use an older version of setuptools, for example version 50.3.2.
+Updates on fixing the incompatibility in pystache can be followed in this GitHub issue: https://github.com/pypa/pypi-support/issues/1422
 
 When running the TrainMLModel instruction multiple times, sometimes it fails saying that there is only one class in the data. Why does this happen?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
added description for temporary workaround with old version of setuptools
included in troubleshooting both under "installation issues" (warnings happen, and the final installed version of immuneML doesn't work) and "runtime errors" (in case warnings during installation are overlooked)