### PR TITLE
small fix in import

### DIFF
--- a/immuneML/util/ImportHelper.py
+++ b/immuneML/util/ImportHelper.py
@@ -256,7 +256,7 @@ class ImportHelper:
                         f"{ImportHelper.__name__}: {n_empty} sequences were removed from the dataset because they contained an empty {sequence_name} "
                         f"sequence after preprocessing. ")
             else:
-                raise ValueError(f"{ImportHelper.__name__}: column {sequence_colname} was not set, but is required for filtering.")
+                warnings.warn(f"{ImportHelper.__name__}: column {sequence_colname} was not set, but is required for filtering. Skipping this filtering...")
 
         return dataframe
 


### PR DESCRIPTION
change error into warning, so files are not always required to contain both amino acid and nt sequences (now it fails for Generic import when only aa sequence is present)