### PR TITLE
Minor fixes

### DIFF
--- a/immuneML/IO/dataset_import/GenericImport.py
+++ b/immuneML/IO/dataset_import/GenericImport.py
@@ -48,7 +48,7 @@ class GenericImport(DataImport):
         import_illegal_characters (bool): Whether to import sequences that contain illegal characters, i.e., characters
         that do not appear in the sequence alphabet (amino acids including stop codon '*', or nucleotides). When set to false, filtering is only
         applied to the sequence type of interest (when running immuneML in amino acid mode, only entries with illegal
-        characters in the amino acid sequence are removed).
+        characters in the amino acid sequence are removed). By default import_illegal_characters is False.
 
         import_empty_nt_sequences (bool): imports sequences which have an empty nucleotide sequence field; can be True or False.
         By default, import_empty_nt_sequences is set to True.
@@ -56,7 +56,7 @@ class GenericImport(DataImport):
         import_empty_aa_sequences (bool): imports sequences which have an empty amino acid sequence field; can be True or False; for analysis on
         amino acid sequences, this parameter should be False (import only non-empty amino acid sequences). By default, import_empty_aa_sequences is set to False.
 
-        region_type (str): Which part of the sequence to import. When IMGT_CDR3 is specified, immuneML assumes the IMGT
+        region_type (str): Which part of the sequence to import. By default, this value is set to IMGT_CDR3. This means immuneML assumes the IMGT
         junction (including leading C and trailing Y/F amino acids) is used in the input file, and the first and last
         amino acids will be removed from the sequences to retrieve the IMGT CDR3 sequence. Specifying any other value
         will result in importing the sequences as they are.
@@ -97,7 +97,7 @@ class GenericImport(DataImport):
         columns_to_load (list): Optional; specifies which columns to load from the input file. This may be useful if
         the input files contain many unused columns. If no value is specified, all columns are loaded.
 
-        separator (str): Required parameter. Column separator, for example "\\t" or ",".
+        separator (str): Required parameter. Column separator, for example "\\t" or ",". The default value is "\\t"
 
 
     YAML specification:

--- a/immuneML/config/default_params/datasets/generic_params.yaml
+++ b/immuneML/config/default_params/datasets/generic_params.yaml
@@ -1,0 +1,8 @@
+is_repertoire: True
+path: ./
+paired: False
+import_illegal_characters: False
+region_type: "IMGT_CDR3" # which region to use - IMGT_CDR3 option means removing first and last amino acid as AIRR uses IMGT junction as CDR3
+separator: "\t"
+import_empty_nt_sequences: True # keep sequences even though the nucleotide sequence might be empty
+import_empty_aa_sequences: False # filter out sequences if they don't have sequence_aa set

--- a/immuneML/encodings/evenness_profile/EvennessProfileEncoder.py
+++ b/immuneML/encodings/evenness_profile/EvennessProfileEncoder.py
@@ -8,6 +8,7 @@ from immuneML.caching.CacheHandler import CacheHandler
 from immuneML.data_model.encoded_data.EncodedData import EncodedData
 from immuneML.encodings.DatasetEncoder import DatasetEncoder
 from immuneML.encodings.EncoderParams import EncoderParams
+from immuneML.util.EncoderHelper import EncoderHelper
 from immuneML.util.ReflectionHandler import ReflectionHandler
 
 
@@ -75,12 +76,12 @@ class EvennessProfileEncoder(DatasetEncoder):
 
     @staticmethod
     def build_object(dataset=None, **params):
-        try:
-            prepared_params = EvennessProfileEncoder._prepare_parameters(**params)
-            encoder = ReflectionHandler.get_class_by_name(EvennessProfileEncoder.dataset_mapping[dataset.__class__.__name__],
+        EncoderHelper.check_dataset_type_available_in_mapping(dataset, EvennessProfileEncoder)
+
+        prepared_params = EvennessProfileEncoder._prepare_parameters(**params)
+        encoder = ReflectionHandler.get_class_by_name(EvennessProfileEncoder.dataset_mapping[dataset.__class__.__name__],
                                                           "evenness_profile/")(**prepared_params)
-        except ValueError:
-            raise ValueError("{} is not defined for dataset of type {}.".format(EvennessProfileEncoder.__name__, dataset.__class__.__name__))
+
         return encoder
 
     def encode(self, dataset, params: EncoderParams):

--- a/immuneML/encodings/kmer_frequency/KmerFrequencyEncoder.py
+++ b/immuneML/encodings/kmer_frequency/KmerFrequencyEncoder.py
@@ -152,12 +152,12 @@ class KmerFrequencyEncoder(DatasetEncoder):
 
     @staticmethod
     def build_object(dataset=None, **params):
-        try:
-            prepared_params = KmerFrequencyEncoder._prepare_parameters(**params)
-            encoder = ReflectionHandler.get_class_by_name(KmerFrequencyEncoder.dataset_mapping[dataset.__class__.__name__],
+        EncoderHelper.check_dataset_type_available_in_mapping(dataset, KmerFrequencyEncoder)
+
+        prepared_params = KmerFrequencyEncoder._prepare_parameters(**params)
+        encoder = ReflectionHandler.get_class_by_name(KmerFrequencyEncoder.dataset_mapping[dataset.__class__.__name__],
                                                           "kmer_frequency/")(**prepared_params)
-        except ValueError:
-            raise ValueError("{} is not defined for dataset of type {}.".format(KmerFrequencyEncoder.__name__, dataset.__class__.__name__))
+
         return encoder
 
     def encode(self, dataset, params: EncoderParams):

--- a/immuneML/encodings/onehot/OneHotEncoder.py
+++ b/immuneML/encodings/onehot/OneHotEncoder.py
@@ -10,6 +10,7 @@ from immuneML.encodings.DatasetEncoder import DatasetEncoder
 from immuneML.encodings.EncoderParams import EncoderParams
 from immuneML.environment.EnvironmentSettings import EnvironmentSettings
 from immuneML.environment.SequenceType import SequenceType
+from immuneML.util.EncoderHelper import EncoderHelper
 from immuneML.util.ParameterValidator import ParameterValidator
 from immuneML.util.ReflectionHandler import ReflectionHandler
 
@@ -135,13 +136,11 @@ class OneHotEncoder(DatasetEncoder):
 
     @staticmethod
     def build_object(dataset=None, **params):
+        EncoderHelper.check_dataset_type_available_in_mapping(dataset, OneHotEncoder)
 
-        try:
-            prepared_params = OneHotEncoder._prepare_parameters(**params)
-            encoder = ReflectionHandler.get_class_by_name(OneHotEncoder.dataset_mapping[dataset.__class__.__name__],
+        prepared_params = OneHotEncoder._prepare_parameters(**params)
+        encoder = ReflectionHandler.get_class_by_name(OneHotEncoder.dataset_mapping[dataset.__class__.__name__],
                                                           "onehot/")(**prepared_params)
-        except ValueError:
-            raise ValueError("{} is not defined for dataset of type {}.".format(OneHotEncoder.__name__, dataset.__class__.__name__))
         return encoder
 
     def encode(self, dataset, params: EncoderParams):

--- a/immuneML/encodings/reference_encoding/MatchedReceptorsEncoder.py
+++ b/immuneML/encodings/reference_encoding/MatchedReceptorsEncoder.py
@@ -9,6 +9,7 @@ from immuneML.data_model.receptor.TCGDReceptor import TCGDReceptor
 from immuneML.encodings.DatasetEncoder import DatasetEncoder
 from immuneML.encodings.EncoderParams import EncoderParams
 from immuneML.encodings.reference_encoding.MatchedReferenceUtil import MatchedReferenceUtil
+from immuneML.util.EncoderHelper import EncoderHelper
 from immuneML.util.ParameterValidator import ParameterValidator
 from immuneML.util.ReadsType import ReadsType
 from immuneML.util.ReflectionHandler import ReflectionHandler
@@ -98,13 +99,11 @@ class MatchedReceptorsEncoder(DatasetEncoder):
 
     @staticmethod
     def build_object(dataset=None, **params):
-        try:
-            prepared_params = MatchedReceptorsEncoder._prepare_parameters(**params)
-            encoder = ReflectionHandler.get_class_by_name(
-                MatchedReceptorsEncoder.dataset_mapping[dataset.__class__.__name__], "reference_encoding/")(**prepared_params)
-        except ValueError:
-            raise ValueError("{} is not defined for dataset of type {}.".format(MatchedReceptorsEncoder.__name__,
-                                                                                dataset.__class__.__name__))
+        EncoderHelper.check_dataset_type_available_in_mapping(dataset, MatchedReceptorsEncoder)
+
+        prepared_params = MatchedReceptorsEncoder._prepare_parameters(**params)
+        encoder = ReflectionHandler.get_class_by_name(MatchedReceptorsEncoder.dataset_mapping[dataset.__class__.__name__], "reference_encoding/")(**prepared_params)
+
         return encoder
 
     def encode(self, dataset, params: EncoderParams):

--- a/immuneML/encodings/reference_encoding/MatchedReferenceUtil.py
+++ b/immuneML/encodings/reference_encoding/MatchedReferenceUtil.py
@@ -52,4 +52,6 @@ class MatchedReferenceUtil:
         else:
             receptors = ImportHelper.import_items(import_class, reference_params["params"]["path"], processed_params)
 
+        assert len(receptors) > 0, f"MatchedReferenceUtil: The total number of imported reference {'receptors' if paired else 'sequences'} is 0, please ensure that reference import is specified correctly."
+
         return receptors

--- a/immuneML/encodings/reference_encoding/MatchedReferenceUtil.py
+++ b/immuneML/encodings/reference_encoding/MatchedReferenceUtil.py
@@ -1,5 +1,6 @@
 import os
 from pathlib import Path
+import logging
 
 from immuneML.IO.dataset_import.DatasetImportParams import DatasetImportParams
 from immuneML.dsl.DefaultParamsLoader import DefaultParamsLoader
@@ -53,5 +54,6 @@ class MatchedReferenceUtil:
             receptors = ImportHelper.import_items(import_class, reference_params["params"]["path"], processed_params)
 
         assert len(receptors) > 0, f"MatchedReferenceUtil: The total number of imported reference {'receptors' if paired else 'sequences'} is 0, please ensure that reference import is specified correctly."
+        logging.info(f"MatchedReferenceUtil: successfully imported {len(receptors)} reference {'receptors' if paired else 'sequences'}.")
 
         return receptors

--- a/immuneML/encodings/reference_encoding/MatchedRegexEncoder.py
+++ b/immuneML/encodings/reference_encoding/MatchedRegexEncoder.py
@@ -8,6 +8,7 @@ from immuneML.caching.CacheHandler import CacheHandler
 from immuneML.data_model.receptor.receptor_sequence.Chain import Chain
 from immuneML.encodings.DatasetEncoder import DatasetEncoder
 from immuneML.encodings.EncoderParams import EncoderParams
+from immuneML.util.EncoderHelper import EncoderHelper
 from immuneML.util.ReadsType import ReadsType
 from immuneML.util.ParameterValidator import ParameterValidator
 from immuneML.util.ReflectionHandler import ReflectionHandler
@@ -120,13 +121,11 @@ class MatchedRegexEncoder(DatasetEncoder):
 
     @staticmethod
     def build_object(dataset=None, **params):
-        try:
-            prepared_params = MatchedRegexEncoder._prepare_parameters(**params)
-            encoder = ReflectionHandler.get_class_by_name(
-                MatchedRegexEncoder.dataset_mapping[dataset.__class__.__name__], "reference_encoding/")(**prepared_params)
-        except ValueError:
-            raise ValueError("{} is not defined for dataset of type {}.".format(MatchedRegexEncoder.__name__,
-                                                                                dataset.__class__.__name__))
+        EncoderHelper.check_dataset_type_available_in_mapping(dataset, MatchedRegexEncoder)
+
+        prepared_params = MatchedRegexEncoder._prepare_parameters(**params)
+        encoder = ReflectionHandler.get_class_by_name(MatchedRegexEncoder.dataset_mapping[dataset.__class__.__name__], "reference_encoding/")(**prepared_params)
+
         return encoder
 
     def encode(self, dataset, params: EncoderParams):

--- a/immuneML/encodings/reference_encoding/MatchedSequencesEncoder.py
+++ b/immuneML/encodings/reference_encoding/MatchedSequencesEncoder.py
@@ -5,6 +5,7 @@ from immuneML.data_model.receptor.receptor_sequence.ReceptorSequenceList import 
 from immuneML.encodings.DatasetEncoder import DatasetEncoder
 from immuneML.encodings.EncoderParams import EncoderParams
 from immuneML.encodings.reference_encoding.MatchedReferenceUtil import MatchedReferenceUtil
+from immuneML.util.EncoderHelper import EncoderHelper
 from immuneML.util.ParameterValidator import ParameterValidator
 from immuneML.util.ReadsType import ReadsType
 from immuneML.util.ReflectionHandler import ReflectionHandler
@@ -82,13 +83,12 @@ class MatchedSequencesEncoder(DatasetEncoder):
 
     @staticmethod
     def build_object(dataset=None, **params):
-        try:
-            prepared_parameters = MatchedSequencesEncoder._prepare_parameters(**params)
-            encoder = ReflectionHandler.get_class_by_name(MatchedSequencesEncoder.dataset_mapping[dataset.__class__.__name__],
+        EncoderHelper.check_dataset_type_available_in_mapping(dataset, MatchedSequencesEncoder)
+
+        prepared_parameters = MatchedSequencesEncoder._prepare_parameters(**params)
+        encoder = ReflectionHandler.get_class_by_name(MatchedSequencesEncoder.dataset_mapping[dataset.__class__.__name__],
                                                           "reference_encoding/")(**prepared_parameters)
-        except ValueError:
-            raise ValueError("{} is not defined for dataset of type {}.".format(MatchedSequencesEncoder.__name__,
-                                                                                dataset.__class__.__name__))
+
         return encoder
 
     def encode(self, dataset, params: EncoderParams):

--- a/immuneML/encodings/word2vec/Word2VecEncoder.py
+++ b/immuneML/encodings/word2vec/Word2VecEncoder.py
@@ -103,13 +103,12 @@ class Word2VecEncoder(DatasetEncoder):
 
     @staticmethod
     def build_object(dataset=None, **params):
-        try:
-            prepared_params = Word2VecEncoder._prepare_parameters(**params)
-            encoder = ReflectionHandler.get_class_by_name(
+        EncoderHelper.check_dataset_type_available_in_mapping(dataset, Word2VecEncoder)
+
+        prepared_params = Word2VecEncoder._prepare_parameters(**params)
+        encoder = ReflectionHandler.get_class_by_name(
                 Word2VecEncoder.dataset_mapping[dataset.__class__.__name__], "word2vec/")(**prepared_params)
-        except ValueError:
-            raise ValueError("{} is not defined for dataset of type {}.".format(Word2VecEncoder.__name__,
-                                                                                dataset.__class__.__name__))
+
         return encoder
 
     def encode(self, dataset, params: EncoderParams):

--- a/immuneML/util/EncoderHelper.py
+++ b/immuneML/util/EncoderHelper.py
@@ -72,4 +72,11 @@ class EncoderHelper:
             f"{class_name}: to use this encoder, in the label definition in the specification of the instruction, define " \
             f"the positive class for the label. Now it is set to '{labels[0].positive_class}'. See documentation for this encoder for more details."
 
+    @staticmethod
+    def check_dataset_type_available_in_mapping(dataset, class_name):
+        if dataset.__class__.__name__ not in class_name.dataset_mapping.keys():
+            raise ValueError(f"{class_name.__name__}: this encoder is not defined for dataset of type {dataset.__class__.__name__}. "
+                             f"Valid dataset types for this encoder are: {', '.join(list(class_name.dataset_mapping.keys()))}")
+
+
 


### PR DESCRIPTION
- specify default params for Generic import: When they are not present, the default params are actually 'None', which leads to confusing behavior because we don't handle it explicitly (e.g., <if param> behaves as <if False>, when param was not explicitly set to False). Generic import behavior is more sensible when default params are the same as for all other importers.
- Do not catch *any* error during Encoder.build_object (misleading error when building the encoder fails for a different reason than specifying the wrong Dataset type). Instead, have one 'dataset type' check for all encoders using dataset_mapping, then run the rest of the Encoder.build_object code. 
- Added assert statement to fail early when references were not successfully imported (len(references)==0) in MatchedReferenceUtil