### PR TITLE
bugfix: Compairr seq abundance memory

### DIFF
--- a/immuneML/config/default_params/encodings/comp_airr_sequence_abundance_params.yaml
+++ b/immuneML/config/default_params/encodings/comp_airr_sequence_abundance_params.yaml
@@ -3,3 +3,4 @@ threads: 8
 compairr_path: Null
 p_value_threshold: 0.05
 sequence_batch_size: 100000
+keep_temporary_files: False

--- a/immuneML/encodings/abundance_encoding/CompAIRRSequenceAbundanceEncoder.py
+++ b/immuneML/encodings/abundance_encoding/CompAIRRSequenceAbundanceEncoder.py
@@ -108,7 +108,6 @@ class CompAIRRSequenceAbundanceEncoder(DatasetEncoder):
                                               output_filename=None,
                                               log_filename=None)
 
-        self.full_sequence_set = None
         self.raw_distance_matrix_np = None
 
     @staticmethod
@@ -149,7 +148,6 @@ class CompAIRRSequenceAbundanceEncoder(DatasetEncoder):
         full_sequence_set = self._get_full_sequence_set(full_dataset)
         sequence_presence_matrix, matrix_repertoire_ids = self._get_sequence_presence(full_dataset, full_sequence_set, params)
 
-        self.full_sequence_set = full_sequence_set
         self.sequence_presence_matrix = sequence_presence_matrix
         self.matrix_repertoire_ids = matrix_repertoire_ids
 
@@ -281,7 +279,7 @@ class CompAIRRSequenceAbundanceEncoder(DatasetEncoder):
 
         relevant_sequence_indices, file_paths = AbundanceEncoderHelper.get_relevant_sequence_indices(sequence_presence_matrix, is_positive_class,
                                                                                                      self.p_value_threshold, self.relevant_indices_path, params)
-        self._write_relevant_sequences_csv(relevant_sequence_indices, params.result_path)
+        self._write_relevant_sequences_csv(dataset, relevant_sequence_indices, params.result_path)
         self._set_file_paths(file_paths)
 
         abundance_matrix = AbundanceEncoderHelper.build_abundance_matrix(sequence_presence_matrix, matrix_repertoire_ids, dataset.get_repertoire_ids(), relevant_sequence_indices)
@@ -293,8 +291,10 @@ class CompAIRRSequenceAbundanceEncoder(DatasetEncoder):
         self.contingency_table_path = file_paths["contingency_table_path"] if "contingency_table_path" in file_paths else None
         self.p_values_path = file_paths["p_values_path"] if "p_values_path" in file_paths else None
 
-    def _write_relevant_sequences_csv(self, relevant_sequence_indices, result_path):
-        relevant_sequences = self.full_sequence_set[relevant_sequence_indices]
+    def _write_relevant_sequences_csv(self, dataset, relevant_sequence_indices, result_path):
+        full_dataset = EncoderHelper.get_current_dataset(dataset, self.context)
+        full_sequence_set = self._get_full_sequence_set(full_dataset)
+        relevant_sequences = full_sequence_set[relevant_sequence_indices]
 
         if self.relevant_sequence_path is None:
             self.relevant_sequence_path = result_path / 'relevant_sequences.csv'

--- a/immuneML/reports/data_reports/SignificantFeatures.py
+++ b/immuneML/reports/data_reports/SignificantFeatures.py
@@ -216,9 +216,15 @@ class SignificantFeatures(DataReport):
         with encoder.relevant_indices_path.open("rb") as file:
             relevant_indices = pickle.load(file)
 
-        relevant_feature_presence = np.sum(encoder.sequence_presence_matrix[relevant_indices], axis=0)
+        with encoder.sequence_presence_matrix_path.open("rb") as file:
+            sequence_presence_matrix = pickle.load(file)
 
-        return self._get_positive_negative_class(relevant_feature_presence, encoder.matrix_repertoire_ids)
+        with encoder.matrix_repertoire_ids_path.open("rb") as file:
+            matrix_repertoire_ids = pickle.load(file)
+
+        relevant_feature_presence = np.sum(sequence_presence_matrix[relevant_indices], axis=0)
+
+        return self._get_positive_negative_class(relevant_feature_presence, matrix_repertoire_ids)
 
     def _get_relevant_feature_presence(self, encoder, relevant_indices):
 

--- a/immuneML/util/SignificantFeaturesHelper.py
+++ b/immuneML/util/SignificantFeaturesHelper.py
@@ -102,7 +102,8 @@ class SignificantFeaturesHelper:
     @staticmethod
     def _build_compairr_sequence_encoder(dataset, p_value, encoder_params, compairr_path):
         encoder = CompAIRRSequenceAbundanceEncoder(p_value_threshold=p_value, compairr_path=compairr_path,
-                                                   sequence_batch_size=100000, ignore_genes=True, threads=8)
+                                                   sequence_batch_size=100000, ignore_genes=True, threads=8,
+                                                   keep_temporary_files=True)
 
         encoder.encode(dataset, encoder_params)
 

--- a/test/encodings/filtered_sequence_encoding/test_CompAIRRSequenceAbundanceEncoder.py
+++ b/test/encodings/filtered_sequence_encoding/test_CompAIRRSequenceAbundanceEncoder.py
@@ -51,7 +51,7 @@ class TestCompAIRRSequenceAbundanceEncoder(TestCase):
             result_path = path / f"ignore_genes={ignore_genes}"
 
             encoder = CompAIRRSequenceAbundanceEncoder.build_object(dataset, **{
-                "p_value_threshold": 0.4, "compairr_path": compairr_path, "sequence_batch_size": 2, "ignore_genes": ignore_genes, "threads": 8
+                "p_value_threshold": 0.4, "compairr_path": compairr_path, "sequence_batch_size": 2, "ignore_genes": ignore_genes, "threads": 8, "keep_temporary_files": False,
             })
 
             label_config = LabelConfiguration([Label("l1", [True, False], positive_class=True)])
@@ -79,6 +79,3 @@ class TestCompAIRRSequenceAbundanceEncoder(TestCase):
             self.assertTrue(np.array_equal(np.array([[0, 4], [0, 6], [0, 3], [0, 6]]), encoded_dataset.encoded_data.examples))
 
         shutil.rmtree(path)
-
-
-    #

--- a/test/encodings/filtered_sequence_encoding/test_CompAIRRSequenceAbundanceEncoder.py
+++ b/test/encodings/filtered_sequence_encoding/test_CompAIRRSequenceAbundanceEncoder.py
@@ -9,7 +9,6 @@ import pandas as pd
 from immuneML.caching.CacheType import CacheType
 from immuneML.data_model.dataset.RepertoireDataset import RepertoireDataset
 from immuneML.encodings.EncoderParams import EncoderParams
-from immuneML.encodings.abundance_encoding.AbundanceEncoderHelper import AbundanceEncoderHelper
 from immuneML.encodings.abundance_encoding.CompAIRRSequenceAbundanceEncoder import CompAIRRSequenceAbundanceEncoder
 from immuneML.environment.Constants import Constants
 from immuneML.environment.EnvironmentSettings import EnvironmentSettings


### PR DESCRIPTION
remove memory-heavy instance variables from CompAIRRSequenceAbundance object, this massively decreases the memory usage when training ML models (when multiple encoder objects are made and stored in memory)