### PR TITLE
Make CompAIRR encoder more RAM efficient

### DIFF
--- a/immuneML/config/default_params/encodings/comp_airr_sequence_abundance_params.yaml
+++ b/immuneML/config/default_params/encodings/comp_airr_sequence_abundance_params.yaml
@@ -2,5 +2,5 @@ ignore_genes: False
 threads: 8
 compairr_path: Null
 p_value_threshold: 0.05
-sequence_batch_size: 100000
+sequence_batch_size: 1000000
 keep_temporary_files: False

--- a/immuneML/encodings/DatasetEncoder.py
+++ b/immuneML/encodings/DatasetEncoder.py
@@ -57,6 +57,7 @@ class DatasetEncoder(metaclass=abc.ABCMeta):
 
     @staticmethod
     def get_additional_files() -> List[str]:
+        '''Should return a list with all the files that need to be stored when storing the encoder.'''
         return []
 
     def set_context(self, context: dict):

--- a/immuneML/encodings/abundance_encoding/CompAIRRBatchIterator.py
+++ b/immuneML/encodings/abundance_encoding/CompAIRRBatchIterator.py
@@ -41,12 +41,13 @@ class CompAIRRBatchIterator:
 
             # count clones only
             batch[batch > 1] = 1
+            batch.sort_index(inplace=True)
 
             yield batch
 
     def get_sequence_vectors(self, repertoire_ids = None):
         for batch in self.get_batches(repertoire_ids):
-            for sequence_idx in sorted(batch.index):
-                yield batch.loc[sequence_idx].to_numpy()
+            for idx, sequence_vector in batch.iterrows():
+                yield sequence_vector.to_numpy()
 
 

--- a/immuneML/encodings/abundance_encoding/CompAIRRBatchIterator.py
+++ b/immuneML/encodings/abundance_encoding/CompAIRRBatchIterator.py
@@ -1,0 +1,52 @@
+from immuneML.util.CompAIRRHelper import CompAIRRHelper
+
+
+class CompAIRRBatchIterator:
+    def __init__(self, paths, sequence_batch_size):
+        self.repertoire_ids = None
+        self.sequence_batch_size = sequence_batch_size
+        self.batch_paths = self.get_batch_dict(paths)
+        self.sequence_count = self.compute_sequence_count()
+
+    def __iter__(self):
+        return self.get_sequence_vectors(self.repertoire_ids)
+
+    def __len__(self):
+        return self.sequence_count
+
+    def compute_sequence_count(self):
+        sequence_count = (len(self.batch_paths) - 1) * self.sequence_batch_size
+
+        last_batch_path = self.batch_paths[max(self.batch_paths.keys())]
+        sequence_count += len(CompAIRRHelper.read_compairr_output_file(last_batch_path))
+
+        return sequence_count
+
+    def get_batch_dict(self, paths):
+        return {self.get_batch_from_path(path): path for path in paths}
+
+    def get_batch_from_path(self, path):
+        return int(path.stem.split("_batch")[1])
+
+    def set_repertoire_ids(self, repertoire_ids):
+        self.repertoire_ids = repertoire_ids
+
+    def get_batches(self, repertoire_ids = None):
+        for batch_idx in sorted(self.batch_paths):
+            path = self.batch_paths[batch_idx]
+            batch = CompAIRRHelper.read_compairr_output_file(path)
+
+            if repertoire_ids is not None:
+                batch = batch[repertoire_ids]
+
+            # count clones only
+            batch[batch > 1] = 1
+
+            yield batch
+
+    def get_sequence_vectors(self, repertoire_ids = None):
+        for batch in self.get_batches(repertoire_ids):
+            for sequence_idx in sorted(batch.index):
+                yield batch.loc[sequence_idx].to_numpy()
+
+

--- a/immuneML/encodings/abundance_encoding/CompAIRRSequenceAbundanceEncoder.py
+++ b/immuneML/encodings/abundance_encoding/CompAIRRSequenceAbundanceEncoder.py
@@ -363,7 +363,5 @@ class CompAIRRSequenceAbundanceEncoder(DatasetEncoder):
     def load_encoder(encoder_file: Path):
         encoder = DatasetEncoder.load_encoder(encoder_file)
         encoder.relevant_indices_path = DatasetEncoder.load_attribute(encoder, encoder_file, "relevant_indices_path")
-        # todo: loader of compairr_sequence_presence
-        # encoder.compairr_sequence_presence = UtilIO.import_comparison_data(encoder_file.parent)
 
         return encoder

--- a/immuneML/encodings/abundance_encoding/SequenceAbundanceEncoder.py
+++ b/immuneML/encodings/abundance_encoding/SequenceAbundanceEncoder.py
@@ -46,7 +46,7 @@ class SequenceAbundanceEncoder(DatasetEncoder):
         p_value_threshold (float): The p value threshold to be used by the statistical test.
 
         sequence_batch_size (int): The number of sequences in a batch when comparing sequences across repertoires, typically 100s of thousands.
-        This does not affect the results of the encoding, only the speed.
+        This does not affect the results of the encoding, only the speed. The default value is 1.000.000
 
         repertoire_batch_size (int): How many repertoires will be loaded at once. This does not affect the result of the encoding, only the speed.
         This value is a trade-off between the number of repertoires that can fit the RAM at the time and loading time from disk.

--- a/immuneML/reports/data_reports/SignificantFeatures.py
+++ b/immuneML/reports/data_reports/SignificantFeatures.py
@@ -202,11 +202,7 @@ class SignificantFeatures(DataReport):
         with encoder.relevant_indices_path.open("rb") as file:
             relevant_indices = pickle.load(file)
 
-        relevant_feature_presence = np.zeros(shape=(6,))
-
-        for i, sequence_vector in enumerate(encoder.comparison_data.get_item_vectors()):
-            if relevant_indices[i]:
-                relevant_feature_presence += sequence_vector
+        relevant_feature_presence = self._sum_sequence_vectors_iterable(relevant_indices, encoder.comparison_data.get_item_vectors())
 
         return self._get_positive_negative_class(relevant_feature_presence, self.dataset.get_repertoire_ids())
 
@@ -216,15 +212,18 @@ class SignificantFeatures(DataReport):
         with encoder.relevant_indices_path.open("rb") as file:
             relevant_indices = pickle.load(file)
 
-        with encoder.sequence_presence_matrix_path.open("rb") as file:
-            sequence_presence_matrix = pickle.load(file)
+        relevant_feature_presence = self._sum_sequence_vectors_iterable(relevant_indices, encoder.compairr_sequence_presence)
 
-        with encoder.matrix_repertoire_ids_path.open("rb") as file:
-            matrix_repertoire_ids = pickle.load(file)
+        return self._get_positive_negative_class(relevant_feature_presence, self.dataset.get_repertoire_ids())
 
-        relevant_feature_presence = np.sum(sequence_presence_matrix[relevant_indices], axis=0)
+    def _sum_sequence_vectors_iterable(self, relevant_indices, sequence_vector_iterable):
+        relevant_feature_presence = np.zeros(shape=(6,))
 
-        return self._get_positive_negative_class(relevant_feature_presence, matrix_repertoire_ids)
+        for i, sequence_vector in enumerate(sequence_vector_iterable):
+            if relevant_indices[i]:
+                relevant_feature_presence += sequence_vector
+
+        return relevant_feature_presence
 
     def _get_relevant_feature_presence(self, encoder, relevant_indices):
 

--- a/immuneML/util/CompAIRRHelper.py
+++ b/immuneML/util/CompAIRRHelper.py
@@ -100,21 +100,27 @@ class CompAIRRHelper:
 
         return repertoire_contents
 
-
     @staticmethod
-    def process_compairr_output_file(subprocess_result, compairr_params, result_path):
+    def verify_compairr_output_path(subprocess_result, compairr_params, result_path):
         output_file = result_path / compairr_params.output_filename
 
         if not output_file.is_file():
-            raise RuntimeError(f"CompAIRRHelper: failed to calculate the distance matrix with CompAIRR ({compairr_params.compairr_path}). "
-                               f"The following error occurred: {subprocess_result.stderr}")
+            raise RuntimeError(
+                f"CompAIRRHelper: failed to calculate the distance matrix with CompAIRR ({compairr_params.compairr_path}). "
+                f"The following error occurred: {subprocess_result.stderr}")
 
         if os.path.getsize(output_file) == 0:
             raise RuntimeError(
                 f"CompAIRRHelper: failed to calculate the distance matrix with CompAIRR ({compairr_params.compairr_path}), output matrix is empty. "
                 f"For details see the log file at {result_path / compairr_params.log_filename}")
 
-        raw_distance_matrix = pd.read_csv(output_file, sep="\t", index_col=0)
+        return output_file
 
-        return raw_distance_matrix
+    @staticmethod
+    def read_compairr_output_file(output_file):
+        return pd.read_csv(output_file, sep="\t", index_col=0)
 
+    @staticmethod
+    def process_compairr_output_file(subprocess_result, compairr_params, result_path):
+        output_file = CompAIRRHelper.verify_compairr_output_path(subprocess_result, compairr_params, result_path)
+        return CompAIRRHelper.read_compairr_output_file(output_file)


### PR DESCRIPTION
- uses CompAIRRBatchIterator object (similar to ComparisonData object) instead of keeping the full overlap table in memory