### PR TITLE
Cleaned up print/logging

### DIFF
--- a/immuneML/api/aggregated_runs/MultiDatasetBenchmarkTool.py
+++ b/immuneML/api/aggregated_runs/MultiDatasetBenchmarkTool.py
@@ -8,6 +8,7 @@ from immuneML.dsl.definition_parsers.ReportParser import ReportParser
 from immuneML.dsl.symbol_table.SymbolTable import SymbolTable
 from immuneML.dsl.symbol_table.SymbolType import SymbolType
 from immuneML.presentation.html.MultiDatasetBenchmarkHTMLBuilder import MultiDatasetBenchmarkHTMLBuilder
+from immuneML.util.Logger import print_log
 from immuneML.util.ParameterValidator import ParameterValidator
 from immuneML.util.PathBuilder import PathBuilder
 
@@ -76,23 +77,23 @@ class MultiDatasetBenchmarkTool:
         self.reports = None
 
     def run(self):
-        print("Starting MultiDatasetBenchmarkTool...", flush=True)
+        print_log("Starting MultiDatasetBenchmarkTool...")
         PathBuilder.build(self.result_path)
         specs = self._split_specs_file()
         self._extract_reports()
         instruction_states = {}
         for index, specs_name in enumerate(specs.keys()):
-            print(f"Running nested cross-validation on dataset {specs_name} ({index+1}/{len(list(specs.keys()))})..", flush=True)
+            print_log(f"Running nested cross-validation on dataset {specs_name} ({index+1}/{len(list(specs.keys()))})..")
             app = ImmuneMLApp(specification_path=specs[specs_name], result_path=self.result_path / specs_name)
             instruction_states[specs_name] = app.run()[0]
-            print(f"Finished nested cross-validation on dataset {specs_name} ({index+1}/{len(list(specs.keys()))})..", flush=True)
+            print_log(f"Finished nested cross-validation on dataset {specs_name} ({index+1}/{len(list(specs.keys()))})..")
 
-        print("Running reports on the results of nested cross-validation on all datasets...", flush=True)
+        print_log("Running reports on the results of nested cross-validation on all datasets...")
         report_results = self._run_reports(instruction_states)
-        print("Finished reports, now generating HTML output...", flush=True)
+        print_log("Finished reports, now generating HTML output...")
         MultiDatasetBenchmarkHTMLBuilder.build(report_results, self.result_path,
                                                {specs_name: self.result_path / specs_name for specs_name in specs.keys()})
-        print("MultiDatasetBenchmarkTool finished.", flush=True)
+        print_log("MultiDatasetBenchmarkTool finished.")
 
     def _extract_reports(self):
         with self.specification_path.open("r") as file:
@@ -171,7 +172,7 @@ class MultiDatasetBenchmarkTool:
     def _run_reports(self, instruction_states: dict):
         report_results = {}
         for index, report in enumerate(self.reports):
-            print(f"Running report {report.name} ({index+1}/{len(self.reports)})...", flush=True)
+            print_log(f"Running report {report.name} ({index+1}/{len(self.reports)})...")
             report.instruction_states = list(instruction_states.values())
             report.result_path = PathBuilder.build(self.result_path / 'benchmarking_reports/')
             report_result = report.generate_report()

--- a/immuneML/api/galaxy/DatasetGenerationTool.py
+++ b/immuneML/api/galaxy/DatasetGenerationTool.py
@@ -6,6 +6,7 @@ import yaml
 from immuneML.api.galaxy.GalaxyTool import GalaxyTool
 from immuneML.api.galaxy.Util import Util
 from immuneML.app.ImmuneMLApp import ImmuneMLApp
+from immuneML.util.Logger import print_log
 from immuneML.util.ParameterValidator import ParameterValidator
 from immuneML.util.PathBuilder import PathBuilder
 from immuneML.workflows.instructions.dataset_generation.DatasetExportInstruction import DatasetExportInstruction
@@ -34,7 +35,7 @@ class DatasetGenerationTool(GalaxyTool):
         self._update_specs()
         state = ImmuneMLApp(self.yaml_path, self.result_path).run()[0]
         shutil.copytree(list(list(state.paths.values())[0].values())[0], self.result_path / "result/")
-        print("Exported dataset.")
+        print_log("Exported dataset.")
 
     def _update_specs(self):
         with self.yaml_path.open('r') as file:

--- a/immuneML/api/galaxy/GalaxyMLApplicationTool.py
+++ b/immuneML/api/galaxy/GalaxyMLApplicationTool.py
@@ -7,6 +7,7 @@ import yaml
 from immuneML.api.galaxy.GalaxyTool import GalaxyTool
 from immuneML.api.galaxy.Util import Util
 from immuneML.app.ImmuneMLApp import ImmuneMLApp
+from immuneML.util.Logger import print_log
 from immuneML.util.ParameterValidator import ParameterValidator
 from immuneML.util.PathBuilder import PathBuilder
 from immuneML.workflows.instructions.ml_model_application.MLApplicationInstruction import MLApplicationInstruction
@@ -24,7 +25,7 @@ class GalaxyMLApplicationTool(GalaxyTool):
         state = ImmuneMLApp(self.yaml_path, self.result_path).run()[0]
         if os.path.relpath(state.predictions_path) != os.path.relpath(self.result_path / "predictions.csv"):
             shutil.copy(state.predictions_path, self.result_path / "predictions.csv")
-        print("Applied ML model to the dataset, predictions are available.")
+        print_log("Applied ML model to the dataset, predictions are available.")
 
     def _check_specs(self):
         with open(self.yaml_path, "r") as file:

--- a/immuneML/app/ImmuneMLApp.py
+++ b/immuneML/app/ImmuneMLApp.py
@@ -1,5 +1,4 @@
 import argparse
-import datetime
 import logging
 import os
 import shutil
@@ -12,6 +11,7 @@ from immuneML.dsl.semantic_model.SemanticModel import SemanticModel
 from immuneML.dsl.symbol_table.SymbolType import SymbolType
 from immuneML.environment.Constants import Constants
 from immuneML.environment.EnvironmentSettings import EnvironmentSettings
+from immuneML.util.Logger import print_log
 from immuneML.util.PathBuilder import PathBuilder
 from immuneML.util.ReflectionHandler import ReflectionHandler
 
@@ -39,11 +39,11 @@ class ImmuneMLApp:
 
         self.set_cache()
 
-        print(f"{datetime.datetime.now()}: ImmuneML: parsing the specification...\n", flush=True)
+        print_log(f"ImmuneML: parsing the specification...\n", include_datetime=True)
 
         symbol_table, self._specification_path = ImmuneMLParser.parse_yaml_file(self._specification_path, self._result_path)
 
-        print(f"{datetime.datetime.now()}: ImmuneML: starting the analysis...\n", flush=True)
+        print_log(f"ImmuneML: starting the analysis...\n", include_datetime=True)
 
         instructions = symbol_table.get_by_type(SymbolType.INSTRUCTION)
         output = symbol_table.get("output")
@@ -52,7 +52,7 @@ class ImmuneMLApp:
 
         self.clear_cache()
 
-        print(f"{datetime.datetime.now()}: ImmuneML: finished analysis.\n", flush=True)
+        print_log(f"ImmuneML: finished analysis.\n", include_datetime=True)
 
         return result
 

--- a/immuneML/dsl/ImmuneMLParser.py
+++ b/immuneML/dsl/ImmuneMLParser.py
@@ -10,6 +10,7 @@ from immuneML.dsl.InstructionParser import InstructionParser
 from immuneML.dsl.OutputParser import OutputParser
 from immuneML.dsl.definition_parsers.DefinitionParser import DefinitionParser
 from immuneML.dsl.symbol_table.SymbolTable import SymbolTable
+from immuneML.util.Logger import print_log
 from immuneML.util.PathBuilder import PathBuilder
 
 
@@ -166,7 +167,7 @@ class ImmuneMLParser:
         with filepath.open("w") as file:
             yaml.dump(result, file)
 
-        print(f"{datetime.datetime.now()}: Full specification is available at {filepath}.\n", flush=True)
+        print_log(f"Full specification is available at {filepath}.\n", include_datetime=True)
         return filepath
 
     @staticmethod

--- a/immuneML/dsl/semantic_model/SemanticModel.py
+++ b/immuneML/dsl/semantic_model/SemanticModel.py
@@ -1,6 +1,6 @@
-import datetime
 from pathlib import Path
 
+from immuneML.util.Logger import print_log
 from immuneML.util.ReflectionHandler import ReflectionHandler
 from immuneML.workflows.instructions.Instruction import Instruction
 
@@ -22,18 +22,18 @@ class SemanticModel:
 
     def build_reports(self, instruction_states):
         report_builder = self.make_report_builder()
-        print(f"{datetime.datetime.now()}: Generating {self.output['format']} reports...", flush=True)
+        print_log(f"Generating {self.output['format']} reports...", include_datetime=True)
         result_path = report_builder.build(instruction_states, self.result_path)
-        print(f"{datetime.datetime.now()}: {self.output['format']} reports are generated.", flush=True)
+        print_log(f"{self.output['format']} reports are generated.", include_datetime=True)
         return result_path
 
     def run_instructions(self) -> list:
         instruction_states = []
         for index, instruction in enumerate(self.instructions):
-            print("{}: Instruction {}/{} has started.".format(datetime.datetime.now(), index+1, len(self.instructions)), flush=True)
+            print_log(f"Instruction {index+1}/{len(self.instructions)} has started.", include_datetime=True)
             result = instruction.run(result_path=self.result_path)
             instruction_states.append(result)
-            print("{}: Instruction {}/{} has finished.".format(datetime.datetime.now(), index+1, len(self.instructions)), flush=True)
+            print_log(f"Instruction {index+1}/{len(self.instructions)} has finished.", include_datetime=True)
         return instruction_states
 
     def make_report_builder(self):

--- a/immuneML/encodings/reference_encoding/MatchedRegexRepertoireEncoder.py
+++ b/immuneML/encodings/reference_encoding/MatchedRegexRepertoireEncoder.py
@@ -1,4 +1,3 @@
-import datetime
 import re
 import warnings
 
@@ -10,6 +9,7 @@ from immuneML.data_model.encoded_data.EncodedData import EncodedData
 from immuneML.data_model.receptor.receptor_sequence.Chain import Chain
 from immuneML.data_model.repertoire.Repertoire import Repertoire
 from immuneML.encodings.EncoderParams import EncoderParams
+from immuneML.util.Logger import print_log
 from immuneML.util.ReadsType import ReadsType
 from immuneML.encodings.reference_encoding.MatchedRegexEncoder import MatchedRegexEncoder
 
@@ -75,7 +75,7 @@ class MatchedRegexRepertoireEncoder(MatchedRegexEncoder):
         n_repertoires = dataset.get_example_count()
 
         for i, repertoire in enumerate(dataset.get_data()):
-            print(f"{datetime.datetime.now()}: Encoding repertoire {i+1}/{n_repertoires}")
+            print_log(f"Encoding repertoire {i+1}/{n_repertoires}", include_datetime=True)
             encoded_repertoires[i] = self._match_repertoire_to_regexes(repertoire)
 
             if labels is not None:

--- a/immuneML/environment/EnvironmentSettings.py
+++ b/immuneML/environment/EnvironmentSettings.py
@@ -1,11 +1,11 @@
 # quality: gold
-import datetime
 import os
 from pathlib import Path
 
 from immuneML.caching.CacheType import CacheType
 from immuneML.environment.Constants import Constants
 from immuneML.environment.SequenceType import SequenceType
+from immuneML.util.Logger import print_log
 from immuneML.util.PathBuilder import PathBuilder
 
 
@@ -38,7 +38,7 @@ class EnvironmentSettings:
         EnvironmentSettings.cache_path = Path(path)
         PathBuilder.build(path)
         os.environ[Constants.CACHE_PATH] = str(EnvironmentSettings.cache_path)
-        print(f"{datetime.datetime.now()}: Setting temporary cache path to {path}", flush=True)
+        print_log(f"Setting temporary cache path to {path}", include_datetime=True)
 
     @staticmethod
     def get_cache_type():

--- a/immuneML/hyperparameter_optimization/core/HPAssessment.py
+++ b/immuneML/hyperparameter_optimization/core/HPAssessment.py
@@ -1,4 +1,3 @@
-import datetime
 from pathlib import Path
 
 from immuneML.data_model.dataset.Dataset import Dataset
@@ -11,6 +10,7 @@ from immuneML.hyperparameter_optimization.states.HPAssessmentState import HPAsse
 from immuneML.hyperparameter_optimization.states.TrainMLModelState import TrainMLModelState
 from immuneML.ml_methods.MLMethod import MLMethod
 from immuneML.reports.ReportUtil import ReportUtil
+from immuneML.util.Logger import print_log
 from immuneML.util.PathBuilder import PathBuilder
 from immuneML.workflows.instructions.MLProcess import MLProcess
 
@@ -39,7 +39,7 @@ class HPAssessment:
     def run_assessment_split(state, train_val_dataset, test_dataset, split_index: int, n_splits):
         """run inner CV loop (selection) and retrain on the full train_val_dataset after optimal model is chosen"""
 
-        print(f'{datetime.datetime.now()}: Training ML model: running outer CV loop: started split {split_index + 1}/{n_splits}.\n', flush=True)
+        print_log(f'Training ML model: running outer CV loop: started split {split_index + 1}/{n_splits}.\n', include_datetime=True)
 
         current_path = HPAssessment.create_assessment_path(state, split_index)
 
@@ -54,7 +54,7 @@ class HPAssessment:
         assessment_state.test_data_reports = ReportUtil.run_data_reports(test_dataset, state.assessment.reports.data_split_reports.values(),
                                                                          current_path / "data_report_test", state.number_of_processes, state.context)
 
-        print(f'{datetime.datetime.now()}: Training ML model: running outer CV loop: finished split {split_index + 1}/{n_splits}.\n', flush=True)
+        print_log(f'Training ML model: running outer CV loop: finished split {split_index + 1}/{n_splits}.\n', include_datetime=True)
 
         return state
 
@@ -65,8 +65,8 @@ class HPAssessment:
 
         for idx, label in enumerate(state.label_configuration.get_label_objects()):
 
-            print(f"{datetime.datetime.now()}: Training ML model: running the inner loop of nested CV: "
-                  f"retrain models for label {label.name} (label {idx + 1} / {n_labels}).\n", flush=True)
+            print_log(f"Training ML model: running the inner loop of nested CV: "
+                  f"retrain models for label {label.name} (label {idx + 1} / {n_labels}).\n", include_datetime=True)
 
             path = state.assessment_states[split_index].path
 
@@ -81,8 +81,8 @@ class HPAssessment:
                 test_dataset = state.assessment_states[split_index].test_dataset
                 state = HPAssessment.reeval_on_assessment_split(state, train_val_dataset, test_dataset, hp_setting, setting_path, label, split_index)
 
-            print(f"{datetime.datetime.now()}: Training ML model: running the inner loop of nested CV: completed retraining models "
-                  f"for label {label.name} (label {idx + 1} / {n_labels}).\n", flush=True)
+            print_log(f"Training ML model: running the inner loop of nested CV: completed retraining models "
+                  f"for label {label.name} (label {idx + 1} / {n_labels}).\n", include_datetime=True)
 
         return state
 

--- a/immuneML/hyperparameter_optimization/core/HPSelection.py
+++ b/immuneML/hyperparameter_optimization/core/HPSelection.py
@@ -1,4 +1,3 @@
-import datetime
 from pathlib import Path
 
 from immuneML.environment.Label import Label
@@ -8,6 +7,7 @@ from immuneML.hyperparameter_optimization.config.SplitType import SplitType
 from immuneML.hyperparameter_optimization.core.HPUtil import HPUtil
 from immuneML.hyperparameter_optimization.states.HPSelectionState import HPSelectionState
 from immuneML.hyperparameter_optimization.states.TrainMLModelState import TrainMLModelState
+from immuneML.util.Logger import print_log
 from immuneML.util.PathBuilder import PathBuilder
 from immuneML.workflows.instructions.MLProcess import MLProcess
 
@@ -32,8 +32,8 @@ class HPSelection:
 
         for idx, label in enumerate(state.label_configuration.get_label_objects()):
 
-            print(f"{datetime.datetime.now()}: Hyperparameter optimization: running the inner loop of nested CV: selection for label {label.name} "
-                  f"(label {idx + 1} / {n_labels}).\n", flush=True)
+            print_log(f"Hyperparameter optimization: running the inner loop of nested CV: selection for label {label.name} "
+                  f"(label {idx + 1} / {n_labels}).\n", include_datetime=True)
 
             selection_state = HPSelectionState(train_datasets, val_datasets, path, state.hp_strategy)
             state.assessment_states[split_index].label_states[label.name].selection_state = selection_state
@@ -46,8 +46,8 @@ class HPSelection:
 
             HPUtil.run_selection_reports(state, train_val_dataset, train_datasets, val_datasets, selection_state)
 
-            print(f"{datetime.datetime.now()}: Hyperparameter optimization: running the inner loop of nested CV: completed selection for "
-                  f"label {label.name} (label {idx + 1} / {n_labels}).\n", flush=True)
+            print_log(f"Hyperparameter optimization: running the inner loop of nested CV: completed selection for "
+                  f"label {label.name} (label {idx + 1} / {n_labels}).\n", include_datetime=True)
 
         return state
 

--- a/immuneML/util/Logger.py
+++ b/immuneML/util/Logger.py
@@ -5,11 +5,11 @@ import logging
 def log(func):
     def wrapped(*args, **kwargs):
         try:
-            logging.info("%s --- Entering: %s with parameters %s" % (datetime.datetime.now(), func.__name__, args))
+            logging.info("--- Entering: %s with parameters %s" % (func.__name__, args))
             try:
                 return func(*args, **kwargs)
             except Exception as e:
-                logging.error('\n\n%s --- Exception in %s : %s\n\n' % (datetime.datetime.now(), func.__name__, e))
+                logging.error('\n\n--- Exception in %s : %s\n\n' % (func.__name__, e))
                 if "dsl" in func.__globals__["__name__"]:
                     raise Exception(f"{e}\n\n"
                                     f"ImmuneMLParser: an error occurred during parsing in function {func.__name__} "
@@ -18,7 +18,14 @@ def log(func):
                 else:
                     raise e
         finally:
-            logging.info("%s --- Exiting: %s" % (datetime.datetime.now(), func.__name__))
+            logging.info("--- Exiting: %s" % (func.__name__))
 
     return wrapped
 
+def print_log(mssg, include_datetime=False):
+    logging.info(mssg)
+
+    if include_datetime:
+        mssg = f"{datetime.datetime.now()}: {mssg}"
+
+    print(mssg, flush=True)

--- a/immuneML/workflows/instructions/MLProcess.py
+++ b/immuneML/workflows/instructions/MLProcess.py
@@ -1,5 +1,4 @@
 import copy
-import datetime
 from pathlib import Path
 from typing import List
 
@@ -12,6 +11,7 @@ from immuneML.hyperparameter_optimization.states.HPItem import HPItem
 from immuneML.ml_metrics.Metric import Metric
 from immuneML.reports.ReportUtil import ReportUtil
 from immuneML.reports.ml_reports.MLReport import MLReport
+from immuneML.util.Logger import print_log
 from immuneML.util.PathBuilder import PathBuilder
 
 
@@ -63,7 +63,7 @@ class MLProcess:
 
     def run(self, split_index: int) -> HPItem:
 
-        print(f"{datetime.datetime.now()}: Evaluating hyperparameter setting: {self.hp_setting}...", flush=True)
+        print_log(f"Evaluating hyperparameter setting: {self.hp_setting}...", include_datetime=True)
 
         PathBuilder.build(self.path)
         self._set_paths()
@@ -81,7 +81,7 @@ class MLProcess:
 
         hp_item = self._assess_on_test_dataset(encoded_train_dataset, encoding_train_results, method, split_index)
 
-        print(f"{datetime.datetime.now()}: Completed hyperparameter setting {self.hp_setting}.\n", flush=True)
+        print_log(f"Completed hyperparameter setting {self.hp_setting}.\n", include_datetime=True)
 
         return hp_item
 

--- a/immuneML/workflows/instructions/TrainMLModelInstruction.py
+++ b/immuneML/workflows/instructions/TrainMLModelInstruction.py
@@ -1,4 +1,3 @@
-import datetime
 from collections import Counter
 from pathlib import Path
 
@@ -15,6 +14,7 @@ from immuneML.hyperparameter_optimization.states.TrainMLModelState import TrainM
 from immuneML.hyperparameter_optimization.strategy.HPOptimizationStrategy import HPOptimizationStrategy
 from immuneML.ml_metrics.Metric import Metric
 from immuneML.reports.train_ml_model_reports.TrainMLModelReport import TrainMLModelReport
+from immuneML.util.Logger import print_log
 from immuneML.util.ReflectionHandler import ReflectionHandler
 from immuneML.workflows.instructions.Instruction import Instruction
 from immuneML.workflows.instructions.MLProcess import MLProcess
@@ -147,29 +147,29 @@ class TrainMLModelInstruction(Instruction):
         optimal_hp_settings = [state.label_states[label.name].optimal_hp_setting for state in self.state.assessment_states]
         optimal_hp_setting = Counter(optimal_hp_settings).most_common(1)[0][0]
         if self.state.refit_optimal_model:
-            print(f"{datetime.datetime.now()}: TrainMLModel: retraining optimal model for label {label.name} {index_repr}.\n", flush=True)
+            print_log(f"TrainMLModel: retraining optimal model for label {label.name} {index_repr}.\n", include_datetime=True)
             self.state.optimal_hp_items[label.name] = MLProcess(self.state.dataset, None, label, self.state.metrics, self.state.optimization_metric,
                                                            self.state.path / f"optimal_{label.name}", number_of_processes=self.state.number_of_processes,
                                                            label_config=self.state.label_configuration, hp_setting=optimal_hp_setting).run(0)
-            print(f"{datetime.datetime.now()}: TrainMLModel: finished retraining optimal model for label {label.name} {index_repr}.\n", flush=True)
+            print_log(f"TrainMLModel: finished retraining optimal model for label {label.name} {index_repr}.\n", include_datetime=True)
 
         else:
             optimal_assessment_state = self.state.assessment_states[optimal_hp_settings.index(optimal_hp_setting)]
             self.state.optimal_hp_items[label.name] = optimal_assessment_state.label_states[label.name].optimal_assessment_item
 
     def print_performances(self, state: TrainMLModelState):
-        print(f"Performances ({state.optimization_metric.name.lower()}) -----------------------------------------------", flush=True)
+        print_log(f"Performances ({state.optimization_metric.name.lower()}) -----------------------------------------------")
 
         for label_name in state.label_configuration.get_labels_by_name():
-            print(f"\n\nLabel: {label_name}", flush=True)
-            print(f"Performance ({state.optimization_metric.name.lower()}) per assessment split:", flush=True)
+            print_log(f"\n\nLabel: {label_name}")
+            print_log(f"Performance ({state.optimization_metric.name.lower()}) per assessment split:")
             for split in range(state.assessment.split_count):
-                print(f"Split {split+1}: {state.assessment_states[split].label_states[label_name].optimal_assessment_item.performance[state.optimization_metric.name.lower()]}", flush=True)
+                print_log(f"Split {split+1}: {state.assessment_states[split].label_states[label_name].optimal_assessment_item.performance[state.optimization_metric.name.lower()]}")
             if all(isinstance(a_state.label_states[label_name].optimal_assessment_item.performance[state.optimization_metric.name.lower()], float)
                    for a_state in state.assessment_states):
-                print(f"Average performance ({state.optimization_metric.name.lower()}): "
-                      f"{sum([state.assessment_states[split].label_states[label_name].optimal_assessment_item.performance[state.optimization_metric.name.lower()] for split in range(state.assessment.split_count)])/state.assessment.split_count}", flush=True)
-            print("------------------------------", flush=True)
+                print_log(f"Average performance ({state.optimization_metric.name.lower()}): "
+                      f"{sum([state.assessment_states[split].label_states[label_name].optimal_assessment_item.performance[state.optimization_metric.name.lower()] for split in range(state.assessment.split_count)])/state.assessment.split_count}")
+            print_log("------------------------------")
 
     def _export_all_performances_to_csv(self):
         self._export_optimal_performances_to_csv()

--- a/immuneML/workflows/instructions/dataset_generation/DatasetExportInstruction.py
+++ b/immuneML/workflows/instructions/dataset_generation/DatasetExportInstruction.py
@@ -1,10 +1,10 @@
-import datetime
 from pathlib import Path
 from typing import List
 
 from immuneML.IO.dataset_export.DataExporter import DataExporter
 from immuneML.data_model.dataset.Dataset import Dataset
 from immuneML.preprocessing.Preprocessor import Preprocessor
+from immuneML.util.Logger import print_log
 from immuneML.util.ReflectionHandler import ReflectionHandler
 from immuneML.workflows.instructions.Instruction import Instruction
 from immuneML.workflows.instructions.dataset_generation.DatasetExportState import DatasetExportState
@@ -63,7 +63,7 @@ class DatasetExportInstruction(Instruction):
             if self.preprocessing_sequence is not None and len(self.preprocessing_sequence) > 0:
                 for preprocessing in self.preprocessing_sequence:
                     dataset = preprocessing.process_dataset(dataset, result_path)
-                    print(f"{datetime.datetime.now()}: Preprocessed dataset {dataset_name} with {preprocessing.__class__.__name__}", flush=True)
+                    print_log(f"Preprocessed dataset {dataset_name} with {preprocessing.__class__.__name__}", include_datetime=True)
 
             paths[dataset_name] = {}
             for exporter in self.exporters:
@@ -72,7 +72,7 @@ class DatasetExportInstruction(Instruction):
                 exporter.export(dataset, path, number_of_processes=self.number_of_processes)
                 paths[dataset_name][export_format] = path
                 contains = str(dataset.__class__.__name__).replace("Dataset", "s").lower()
-                print(f"{datetime.datetime.now()}: Exported dataset {dataset_name} containing {dataset.get_example_count()} {contains} in {export_format} format.", flush=True)
+                print_log(f"Exported dataset {dataset_name} containing {dataset.get_example_count()} {contains} in {export_format} format.", include_datetime=True)
 
         return DatasetExportState(datasets=self.datasets, formats=[exporter.__name__[:-8] for exporter in self.exporters],
                                   preprocessing_sequence=self.preprocessing_sequence, paths=paths, result_path=self.result_path, name=self.name)

--- a/immuneML/workflows/instructions/exploratory_analysis/ExploratoryAnalysisInstruction.py
+++ b/immuneML/workflows/instructions/exploratory_analysis/ExploratoryAnalysisInstruction.py
@@ -1,9 +1,9 @@
-import datetime
 from pathlib import Path
 
 from immuneML.data_model.dataset.Dataset import Dataset
 from immuneML.encodings.EncoderParams import EncoderParams
 from immuneML.reports.ReportResult import ReportResult
+from immuneML.util.Logger import print_log
 from immuneML.util.PathBuilder import PathBuilder
 from immuneML.workflows.instructions.Instruction import Instruction
 from immuneML.workflows.instructions.exploratory_analysis.ExploratoryAnalysisState import ExploratoryAnalysisState
@@ -65,12 +65,12 @@ class ExploratoryAnalysisInstruction(Instruction):
         name = self.name if self.name is not None else "exploratory_analysis"
         self.state.result_path = result_path / name
         for index, (key, unit) in enumerate(self.state.exploratory_analysis_units.items()):
-            print("{}: Started analysis {} ({}/{}).".format(datetime.datetime.now(), key, index+1, len(self.state.exploratory_analysis_units)), flush=True)
+            print_log(f"Started analysis {key} ({index+1}/{len(self.state.exploratory_analysis_units)}).", include_datetime=True)
             path = self.state.result_path / f"analysis_{key}"
             PathBuilder.build(path)
             report_result = self.run_unit(unit, path)
             unit.report_result = report_result
-            print("{}: Finished analysis {} ({}/{}).\n".format(datetime.datetime.now(), key, index+1, len(self.state.exploratory_analysis_units)), flush=True)
+            print_log(f"Finished analysis {key} ({index+1}/{len(self.state.exploratory_analysis_units)}).\n", include_datetime=True)
         return self.state
 
     def run_unit(self, unit: ExploratoryAnalysisUnit, result_path: Path) -> ReportResult:

--- a/immuneML/workflows/steps/DataEncoder.py
+++ b/immuneML/workflows/steps/DataEncoder.py
@@ -1,5 +1,4 @@
-import datetime
-
+from immuneML.util.Logger import print_log
 from immuneML.workflows.steps.DataEncoderParams import DataEncoderParams
 from immuneML.workflows.steps.Step import Step
 from immuneML.workflows.steps.StepParams import StepParams
@@ -16,10 +15,10 @@ class DataEncoder(Step):
         encoder = input_params.encoder
         encoder_params = input_params.encoder_params
 
-        print(f"{datetime.datetime.now()}: Encoding started...")
+        print_log(f"Encoding started...", include_datetime=True)
 
         encoded_dataset = encoder.encode(dataset, encoder_params)
 
-        print(f"{datetime.datetime.now()}: Encoding finished.")
+        print_log(f"Encoding finished.", include_datetime=True)
 
         return encoded_dataset

--- a/immuneML/workflows/steps/MLMethodTrainer.py
+++ b/immuneML/workflows/steps/MLMethodTrainer.py
@@ -1,9 +1,9 @@
 import copy
-import datetime
 
 import pandas as pd
 
 from immuneML.ml_methods.MLMethod import MLMethod
+from immuneML.util.Logger import print_log
 from immuneML.workflows.steps.MLMethodTrainerParams import MLMethodTrainerParams
 from immuneML.workflows.steps.Step import Step
 
@@ -13,12 +13,12 @@ class MLMethodTrainer(Step):
     @staticmethod
     def run(input_params: MLMethodTrainerParams = None):
 
-        print(f"{datetime.datetime.now()}: ML model training started...", flush=True)
+        print_log(f"ML model training started...", include_datetime=True)
 
         method = MLMethodTrainer._fit_method(input_params)
         MLMethodTrainer.store(method, input_params)
 
-        print(f"{datetime.datetime.now()}: ML model training finished.", flush=True)
+        print_log(f"ML model training finished.", include_datetime=True)
 
         return method
 


### PR DESCRIPTION
I found it annoying that the regular immuneML print statements are not shown in the log file. I think much of the logging becomes more understandable by knowing where during the immuneML run it was encountered. 

Added print_log utility function:
- to be called instead of print
- prints with flush AND writes to logging.info
- takes care of optional datetime in front of print statement

Fix in log function: logging of entering/exiting methods showed datetime double (because it was added inside log() as well as logging.basicConfig.format)

Some examples of log files using the old code vs this new code:
[old_logfile_example.txt](https://github.com/uio-bmi/immuneML/files/9706859/old_logfile_example.txt)
[new_logfile_example.txt](https://github.com/uio-bmi/immuneML/files/9706863/new_logfile_example.txt)
