### PR TITLE
Attempt at fixing compatibility with Python 3.10

### DIFF
--- a/immuneML/ml_methods/SklearnMethod.py
+++ b/immuneML/ml_methods/SklearnMethod.py
@@ -7,7 +7,7 @@ import dill
 import numpy as np
 import pkg_resources
 import yaml
-from sklearn.metrics import SCORERS
+from sklearn.metrics import _scorer as SCORERS
 from sklearn.model_selection import RandomizedSearchCV
 from sklearn.utils.validation import check_is_fitted
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ pytest>=4
 pandas>=1,<=1.5.3
 PyYAML>=5.3
 scikit-learn>=0.23
-gensim>=3.8
+gensim>=3.8,>=4.3
 matplotlib>=3.1
 editdistance
 regex

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     author_email="milenpa@student.matnat.uio.no",
     url="https://github.com/uio-bmi/immuneML",
     install_requires=["numpy>=1.18.5,<=1.23.5", "pytest>=4", "pandas>=1,<=1.5.3", "PyYAML>=5.3", "scikit-learn>=0.23",
-                      "gensim>=3.8", "matplotlib>=3.1", "editdistance", "regex", "tzlocal", "airr>=1,<1.4",
+                      "gensim>=4.3", "matplotlib>=3.1", "editdistance", "regex", "tzlocal", "airr>=1,<1.4",
                       "fishersapi", "pystache", "torch>=1.5.1", "dill>=0.3", "plotly>=4", "logomaker>=0.8",
                       "matplotlib-venn>=0.11", "scipy"],
     extras_require={


### PR DESCRIPTION
Hi folks,

I ran into a few issues running ImmuneML with Python 3.10.
It was complaining about gensim but bumping its version to 4.3 seems to have fixed it (according to https://pypi.org/project/gensim/).

Also updated a variable used by sklearn which seems to have mysteriously changed its name (couldn't fix documentation regarding this issue so I had to dig a bit into their source-code).

It seems to work fine, but are there any formal tests that I could run to make sure everything is working?

All the best,
Alex