### PR TITLE
bugfix: element dataset paths

### DIFF
--- a/immuneML/data_model/dataset/ElementDataset.py
+++ b/immuneML/data_model/dataset/ElementDataset.py
@@ -16,45 +16,61 @@ class ElementDataset(Dataset):
     """
 
     @classmethod
-    def build(cls, dataset_file: Path, types: dict = None, filenames: list = None, **kwargs):
+    def build(cls, dataset_file: Path, types: dict = None, filenames: list = None, batchfiles_path: Path = None, **kwargs):
         if not Path(dataset_file).exists():
             metadata = {
                 'type_dict': {key: SequenceSet.TYPE_TO_STR[val] for key, val in types.items()},
                 'dataset_class': cls.__name__, 'element_class_name': kwargs['element_class_name'],
-                'filenames': [str(file) for file in filenames]
+                'filenames': [str(file) for file in filenames],
+                'batchfiles_path': str(batchfiles_path)
             }
             write_yaml(dataset_file, metadata)
-        return cls(**{**kwargs, 'dataset_file': dataset_file, 'filenames': filenames})
+        return cls(**{**kwargs, 'dataset_file': dataset_file, 'filenames': filenames, 'batchfiles_path': batchfiles_path})
+
+    @staticmethod
+    def parse_filenames(filenames):
+        filenames = [Path(filename) for filename in filenames] if filenames is not None else []
+        for filename in filenames:
+            assert str(filename) == str(filename.name), "ElementDataset: filenames must only contain the names of files, not the full path. " \
+                                                        "To supply the name of the folder where the files are stored, use parameter batchfiles_path. " \
+                                                        f"This error was caused by the following filename: {filename} (should be {filename.name})"
+
+        return filenames
 
     def __init__(self, labels: dict = None, encoded_data: EncodedData = None, filenames: list = None,
-                 identifier: str = None, dataset_file: Path = None,
+                 batchfiles_path: Path = None, identifier: str = None, dataset_file: Path = None,
                  file_size: int = 100000, name: str = None, element_class_name: str = None,
                  element_ids: list = None, example_weights: list = None,
                  buffer_type=None):
         super().__init__(encoded_data, name, identifier if identifier is not None else uuid4().hex, labels, example_weights)
-        self.filenames = filenames if filenames is not None else []
-        self.filenames = [Path(filename) for filename in self.filenames]
+        self.batchfiles_path = Path(batchfiles_path)
+        self.filenames = ElementDataset.parse_filenames(filenames)
         if buffer_type is None:
             buffer_type = make_buffer_type_from_dataset_file(Path(dataset_file))
-        self.element_generator = ElementGenerator(self.filenames, file_size, element_class_name, buffer_type)
+
+        self.element_generator = ElementGenerator([self.batchfiles_path / filename for filename in self.filenames],
+                                                  file_size, element_class_name, buffer_type)
         self.file_size = file_size
         self.element_ids = element_ids
         self.element_class_name = element_class_name
         self.dataset_file = Path(dataset_file)
 
     def get_data(self, batch_size: int = 10000, return_objects: bool = True):
-        self.element_generator.file_list = self.filenames
+        self.element_generator.file_list = self.get_filenames_full_path()
         return self.element_generator.build_element_generator(return_objects=return_objects)
 
     def get_batch(self, batch_size: int = 10000):
-        self.element_generator.file_list = self.filenames
+        self.element_generator.file_list = self.get_filenames_full_path()
         return self.element_generator.build_batch_generator()
+
+    def get_filenames_full_path(self):
+        return [self.batchfiles_path / filename for filename in self.filenames]
 
     def get_filenames(self):
         return self.filenames
 
     def set_filenames(self, filenames):
-        self.filenames = filenames
+        self.filenames = ElementDataset.parse_filenames(filenames)
 
     def get_example_count(self):
         return len(self.get_example_ids())
@@ -102,12 +118,12 @@ class ElementDataset(Dataset):
 
         types = read_yaml(self.dataset_file)['type_dict']
 
-        new_dataset = self.__class__.build(labels=self.labels, file_size=self.file_size, filenames=batch_filenames,
+        new_dataset = self.__class__.build(labels=self.labels, file_size=self.file_size,
+                                           filenames=batch_filenames, batchfiles_path=path,
                                            element_class_name=self.element_generator.element_class_name,
                                            dataset_file=path / f"{dataset_name}.yaml", types=types,
                                            identifier=new_dataset_id, name=dataset_name)
 
-        # todo check if this is necessary
         original_example_weights = self.get_example_weights()
         if original_example_weights is not None:
             new_dataset.set_example_weights([original_example_weights[i] for i in example_indices])

--- a/immuneML/data_model/dataset/ReceptorDataset.py
+++ b/immuneML/data_model/dataset/ReceptorDataset.py
@@ -22,27 +22,27 @@ class ReceptorDataset(ElementDataset):
                            labels: dict = None):
 
         file_count = math.ceil(len(receptors) / file_size)
-        file_names = [
-            path / f"batch{''.join(['0' for i in range(1, len(str(file_count)) - len(str(index)) + 1)])}{index}.tsv"
-            for index in range(1, file_count + 1)]
+        filenames = [f"batch{''.join(['0' for i in range(1, len(str(file_count)) - len(str(index)) + 1)])}{index}.tsv"
+                     for index in range(1, file_count + 1)]
 
         receptor_dc, types = make_dynamic_seq_set_from_objs(receptors)
 
         for index in range(file_count):
             field_vals = get_receptor_attributes_for_bnp(receptors[index * file_size:(index + 1) * file_size], receptor_dc, types)
             receptor_matrix = receptor_dc(**field_vals)
-            bnp_write_to_file(file_names[index], receptor_matrix)
+            bnp_write_to_file(path / filenames[index], receptor_matrix)
 
         dataset_metadata = {'type_dict': {key: SequenceSet.TYPE_TO_STR[val] for key, val in types.items()},
                             'element_class_name': type(receptors[0]).__name__,
                             'dataset_class': 'ReceptorDataset',
-                            'filenames': [str(file) for file in file_names]}
+                            'filenames': filenames,
+                            'batchfiles_path': str(path)}
         metadata_filename = path / f'dataset_{name}.yaml'
         write_yaml(metadata_filename, dataset_metadata)
 
-        return ReceptorDataset(filenames=file_names, file_size=file_size, name=name, labels=labels,
+        return ReceptorDataset(filenames=filenames, file_size=file_size, name=name, labels=labels,
                                element_class_name=type(receptors[0]).__name__ if len(receptors) > 0 else None,
-                               dataset_file=metadata_filename,
+                               dataset_file=metadata_filename, batchfiles_path=path,
                                buffer_type=bnp.io.delimited_buffers.get_bufferclass_for_datatype(receptor_dc,
                                                                                                  delimiter='\t',
                                                                                                  has_header=True))
@@ -57,7 +57,8 @@ class ReceptorDataset(ElementDataset):
         return pd.DataFrame(result) if return_df else result
 
     def clone(self, keep_identifier: bool = False):
-        dataset = ReceptorDataset(self.labels, copy.deepcopy(self.encoded_data), copy.deepcopy(self.filenames),
+        dataset = ReceptorDataset(labels=self.labels, encoded_data=copy.deepcopy(self.encoded_data),
+                                  filenames=copy.deepcopy(self.filenames), batchfiles_path=copy.deepcopy(self.batchfiles_path),
                                   file_size=self.file_size, dataset_file=copy.deepcopy(self.dataset_file),
                                   name=self.name, element_class_name=self.element_generator.element_class_name)
         if keep_identifier:

--- a/immuneML/data_model/dataset/RepertoireDataset.py
+++ b/immuneML/data_model/dataset/RepertoireDataset.py
@@ -78,9 +78,6 @@ class RepertoireDataset(Dataset):
             dataset.identifier = self.identifier
         return dataset
 
-    def add_encoded_data(self, encoded_data: EncodedData):
-        self.encoded_data = encoded_data
-
     def get_data(self, batch_size: int = 1):
         return self.repertoires
 

--- a/immuneML/data_model/receptor/ElementGenerator.py
+++ b/immuneML/data_model/receptor/ElementGenerator.py
@@ -100,27 +100,26 @@ class ElementGenerator:
 
         example_indices.sort()
 
-        batch_filenames = self._prepare_batch_filenames(len(example_indices), path, dataset_type, dataset_identifier)
+        batch_filenames = self._prepare_batch_filenames(len(example_indices), dataset_type, dataset_identifier)
 
         for index, batch in enumerate(self.build_batch_generator(return_objects=False)):
             extracted_elements = self._extract_elements_from_batch(index, batch, example_indices, paired=paired)
             elements = merge_dataclass_objects([elements, extracted_elements]) if elements else extracted_elements
 
             if len(elements) >= tmp_file_size or len(elements) == len(example_indices):
-                bnp_write_to_file(batch_filenames[file_count - 1], elements[:tmp_file_size])
+                bnp_write_to_file(path / batch_filenames[file_count - 1], elements[:tmp_file_size])
                 file_count += 1
                 elements = elements[tmp_file_size:]
 
         if len(elements) > 0:
-            bnp_write_to_file(batch_filenames[file_count - 1], elements)
+            bnp_write_to_file(path / batch_filenames[file_count - 1], elements)
 
         return batch_filenames
 
-    def _prepare_batch_filenames(self, example_count: int, path: Path, dataset_type: str, dataset_identifier: str):
+    def _prepare_batch_filenames(self, example_count: int, dataset_type: str, dataset_identifier: str):
         batch_count = math.ceil(example_count / self.file_size)
         digits_count = len(str(batch_count)) + 1
-        filenames = [
-            path / f"{dataset_identifier}_{dataset_type}_batch{''.join(['0' for _ in range(digits_count - len(str(index)))])}{index}.tsv"
+        filenames = [f"{dataset_identifier}_{dataset_type}_batch{''.join(['0' for _ in range(digits_count - len(str(index)))])}{index}.tsv"
             for index in range(batch_count)]
         return filenames
 

--- a/immuneML/encodings/abundance_encoding/CompAIRRSequenceAbundanceEncoder.py
+++ b/immuneML/encodings/abundance_encoding/CompAIRRSequenceAbundanceEncoder.py
@@ -292,7 +292,8 @@ class CompAIRRSequenceAbundanceEncoder(DatasetEncoder):
                                          "contingency_table_path": self.contingency_table_path,
                                          "p_values_path": self.p_values_path})
 
-        encoded_dataset = RepertoireDataset(labels=dataset.labels, encoded_data=encoded_data, repertoires=dataset.repertoires)
+        encoded_dataset = dataset.clone()
+        encoded_dataset.encoded_data = encoded_data
 
         return encoded_dataset
 

--- a/immuneML/encodings/abundance_encoding/KmerAbundanceEncoder.py
+++ b/immuneML/encodings/abundance_encoding/KmerAbundanceEncoder.py
@@ -179,7 +179,8 @@ class KmerAbundanceEncoder(DatasetEncoder):
                                          "contingency_table_path": self.contingency_table_path,
                                          "p_values_path": self.p_values_path})
 
-        encoded_dataset = RepertoireDataset(labels=dataset.labels, encoded_data=encoded_data, repertoires=dataset.repertoires)
+        encoded_dataset = dataset.clone()
+        encoded_dataset.encoded_data = encoded_data
 
         return encoded_dataset
 

--- a/immuneML/encodings/abundance_encoding/SequenceAbundanceEncoder.py
+++ b/immuneML/encodings/abundance_encoding/SequenceAbundanceEncoder.py
@@ -125,7 +125,8 @@ class SequenceAbundanceEncoder(DatasetEncoder):
                                                                                      "contingency_table_path": self.contingency_table_path,
                                                                                      "p_values_path": self.p_values_path})
 
-        encoded_dataset = RepertoireDataset(labels=dataset.labels, encoded_data=encoded_data, repertoires=dataset.repertoires)
+        encoded_dataset = dataset.clone()
+        encoded_dataset.encoded_data = encoded_data
 
         return encoded_dataset
 

--- a/immuneML/encodings/evenness_profile/EvennessProfileRepertoireEncoder.py
+++ b/immuneML/encodings/evenness_profile/EvennessProfileRepertoireEncoder.py
@@ -21,10 +21,8 @@ class EvennessProfileRepertoireEncoder(EvennessProfileEncoder):
 
         encoded_data = self._encode_data(dataset, params)
 
-        encoded_dataset = RepertoireDataset(repertoires=dataset.repertoires,
-                                            encoded_data=encoded_data,
-                                            labels=dataset.labels,
-                                            metadata_file=dataset.metadata_file)
+        encoded_dataset = dataset.clone()
+        encoded_dataset.encoded_data = encoded_data
 
         return encoded_dataset
 

--- a/immuneML/encodings/kmer_frequency/KmerFreqRepertoireEncoder.py
+++ b/immuneML/encodings/kmer_frequency/KmerFreqRepertoireEncoder.py
@@ -16,12 +16,11 @@ class KmerFreqRepertoireEncoder(KmerFrequencyEncoder):
 
         encoded_data = self._encode_data(dataset, params)
 
-        encoded_dataset = RepertoireDataset(repertoires=dataset.repertoires,
-                                            encoded_data=encoded_data,
-                                            labels=dataset.labels,
-                                            metadata_file=dataset.metadata_file)
+        encoded_dataset = dataset.clone()
+        encoded_dataset.encoded_data = encoded_data
 
         return encoded_dataset
+
 
     @log
     def _encode_examples(self, dataset, params: EncoderParams):

--- a/immuneML/encodings/kmer_frequency/KmerFreqSequenceEncoder.py
+++ b/immuneML/encodings/kmer_frequency/KmerFreqSequenceEncoder.py
@@ -11,9 +11,8 @@ class KmerFreqSequenceEncoder(KmerFrequencyEncoder):
 
         encoded_data = self._encode_data(dataset, params)
 
-        encoded_dataset = SequenceDataset(filenames=dataset.get_filenames(), dataset_file=dataset.dataset_file,
-                                          encoded_data=encoded_data,
-                                          labels=dataset.labels)
+        encoded_dataset = dataset.clone()
+        encoded_dataset.encoded_data = encoded_data
 
         return encoded_dataset
 

--- a/immuneML/encodings/onehot/OneHotRepertoireEncoder.py
+++ b/immuneML/encodings/onehot/OneHotRepertoireEncoder.py
@@ -27,10 +27,8 @@ class OneHotRepertoireEncoder(OneHotEncoder):
     def _encode_new_dataset(self, dataset, params: EncoderParams):
         encoded_data = self._encode_data(dataset, params)
 
-        encoded_dataset = RepertoireDataset(repertoires=dataset.repertoires,
-                                            encoded_data=encoded_data,
-                                            labels=dataset.labels,
-                                            metadata_file=dataset.metadata_file)
+        encoded_dataset = dataset.clone()
+        encoded_dataset.encoded_data = encoded_data
 
         return encoded_dataset
 

--- a/immuneML/encodings/onehot/OneHotSequenceEncoder.py
+++ b/immuneML/encodings/onehot/OneHotSequenceEncoder.py
@@ -18,10 +18,8 @@ class OneHotSequenceEncoder(OneHotEncoder):
     def _encode_new_dataset(self, dataset: SequenceDataset, params: EncoderParams):
         encoded_data = self._encode_data(dataset, params)
 
-        encoded_dataset = SequenceDataset(filenames=dataset.get_filenames(),
-                                          encoded_data=encoded_data,
-                                          labels=dataset.labels,
-                                          file_size=dataset.file_size, dataset_file=dataset.dataset_file)
+        encoded_dataset = dataset.clone()
+        encoded_dataset.encoded_data = encoded_data
 
         return encoded_dataset
 

--- a/immuneML/encodings/reference_encoding/MatchedReceptorsEncoder.py
+++ b/immuneML/encodings/reference_encoding/MatchedReceptorsEncoder.py
@@ -155,11 +155,6 @@ class MatchedReceptorsEncoder(DatasetEncoder):
                 ("encoding_params", encoding_params_desc), )
 
     def _encode_new_dataset(self, dataset, params: EncoderParams):
-        pass
-
-        encoded_dataset = RepertoireDataset(repertoires=dataset.repertoires, labels=dataset.labels,
-                                            metadata_file=dataset.metadata_file)
-
         feature_annotations = None if self.sum_matches else self._get_feature_info()
 
         if self.sum_matches:
@@ -171,18 +166,15 @@ class MatchedReceptorsEncoder(DatasetEncoder):
         encoded_repertoires, labels, example_ids = self._encode_repertoires(dataset, params)
         encoded_repertoires = self._normalize(dataset, encoded_repertoires) if self.normalize else encoded_repertoires
 
-        encoded_dataset.add_encoded_data(EncodedData(
-            # examples contains a np.ndarray with counts
+        encoded_dataset = dataset.clone()
+        encoded_dataset.encoded_data = EncodedData(
             examples=encoded_repertoires,
-            # example_ids contains a list of repertoire identifiers
             example_ids=example_ids,
-            # feature_names contains a list of reference receptor identifiers
             feature_names=feature_names,
-            # feature_annotations contains a PD dataframe with sequence and VDJ gene usage per reference receptor
             feature_annotations=feature_annotations,
             labels=labels,
             encoding=MatchedReceptorsEncoder.__name__
-        ))
+        )
 
         return encoded_dataset
 

--- a/immuneML/encodings/reference_encoding/MatchedRegexRepertoireEncoder.py
+++ b/immuneML/encodings/reference_encoding/MatchedRegexRepertoireEncoder.py
@@ -19,13 +19,11 @@ class MatchedRegexRepertoireEncoder(MatchedRegexEncoder):
     def _encode_new_dataset(self, dataset, params: EncoderParams):
         self._load_regex_df()
 
-        encoded_dataset = RepertoireDataset(repertoires=dataset.repertoires, labels=dataset.labels,
-                                            metadata_file=dataset.metadata_file)
-
         feature_annotations = self._get_feature_info()
         encoded_repertoires, labels = self._encode_repertoires(dataset, params)
 
-        encoded_dataset.add_encoded_data(EncodedData(
+        encoded_dataset = dataset.clone()
+        encoded_dataset.encoded_data = EncodedData(
             examples=encoded_repertoires,
             example_ids=dataset.get_example_ids(), #list(dataset.get_metadata(["subject_id"]).values())[0],
             example_weights=dataset.get_example_weights(),
@@ -33,7 +31,7 @@ class MatchedRegexRepertoireEncoder(MatchedRegexEncoder):
             feature_annotations=feature_annotations,
             labels=labels,
             encoding=MatchedRegexEncoder.__name__
-        ))
+        )
 
         return encoded_dataset
 

--- a/immuneML/encodings/reference_encoding/MatchedSequencesEncoder.py
+++ b/immuneML/encodings/reference_encoding/MatchedSequencesEncoder.py
@@ -132,9 +132,6 @@ class MatchedSequencesEncoder(DatasetEncoder):
                 ("encoding_params", encoding_params_desc),)
 
     def _encode_new_dataset(self, dataset, params: EncoderParams):
-        encoded_dataset = RepertoireDataset(repertoires=dataset.repertoires, labels=dataset.labels,
-                                            metadata_file=dataset.metadata_file)
-
         encoded_repertoires, labels = self._encode_repertoires(dataset, params)
 
         encoded_repertoires = self._normalize(dataset, encoded_repertoires) if self.normalize else encoded_repertoires
@@ -142,14 +139,15 @@ class MatchedSequencesEncoder(DatasetEncoder):
         feature_annotations = None if self.sum_matches else self._get_feature_info()
         feature_names = [f"sum_of_{self.reads.value}_reads"] if self.sum_matches else list(feature_annotations["sequence_desc"])
 
-        encoded_dataset.add_encoded_data(EncodedData(
+        encoded_dataset = dataset.clone()
+        encoded_dataset.encoded_data = EncodedData(
             examples=encoded_repertoires,
             labels=labels,
             feature_names=feature_names,
             feature_annotations=feature_annotations,
             example_ids=[repertoire.identifier for repertoire in dataset.get_data()],
             encoding=MatchedSequencesEncoder.__name__
-        ))
+        )
 
         return encoded_dataset
 

--- a/immuneML/simulation/dataset_generation/RandomDatasetGenerator.py
+++ b/immuneML/simulation/dataset_generation/RandomDatasetGenerator.py
@@ -98,7 +98,9 @@ class RandomDatasetGenerator:
         repertoires, metadata = RepertoireBuilder.build(sequences=sequences, path=path, labels=processed_labels)
         dataset = RepertoireDataset(labels=dataset_params, repertoires=repertoires, metadata_file=metadata, name=name)
 
-        return ImmuneMLExporter.export(dataset, path)
+        ImmuneMLExporter.export(dataset, path)
+
+        return dataset
 
 
     @staticmethod
@@ -178,7 +180,9 @@ class RandomDatasetGenerator:
         processed_labels, dataset_params = RandomDatasetGenerator._make_labels(labels, receptor_count)
         dataset= ReceptorDataset.build_from_objects(receptors, 100, path, name="receptor_dataset", labels=dataset_params)
 
-        return ImmuneMLExporter.export(dataset, path)
+        ImmuneMLExporter.export(dataset, path)
+
+        return dataset
 
     @staticmethod
     def _check_sequence_dataset_generation_params(receptor_count: int, length_probabilities: dict, labels: dict,
@@ -238,5 +242,7 @@ class RandomDatasetGenerator:
         dataset = SequenceDataset.build_from_objects(sequences, sequence_count, path, name="sequence_dataset",
                                                   labels=dataset_params)
 
-        return ImmuneMLExporter.export(dataset, path)
+        ImmuneMLExporter.export(dataset, path)
+
+        return dataset
 

--- a/test/IO/dataset_import/test_tenxGenomicsImport.py
+++ b/test/IO/dataset_import/test_tenxGenomicsImport.py
@@ -74,7 +74,7 @@ rep2.tsv,2""")
         dataset = TenxGenomicsImport.import_dataset(params, "tenx_dataset_sequence")
 
         self.assertEqual(6, dataset.get_example_count())
-        self.assertEqual(6, len(dataset.get_filenames()))
+        self.assertEqual(6, len(dataset.filenames))
 
         data = dataset.get_data(1)
         for receptorseq in data:

--- a/test/reports/ml_reports/test_BinaryFeaturePrecisionRecall.py
+++ b/test/reports/ml_reports/test_BinaryFeaturePrecisionRecall.py
@@ -65,8 +65,8 @@ class TestBinaryFeaturePrecisionRecall(TestCase):
         report.method = motif_classifier
         report.label = label
         report.result_path = path
-        report.train_dataset = SequenceDataset(buffer_type="NA", dataset_file="")
-        report.test_dataset = SequenceDataset(buffer_type="NA", dataset_file="")
+        report.train_dataset = SequenceDataset(buffer_type="NA", dataset_file="", batchfiles_path="")
+        report.test_dataset = SequenceDataset(buffer_type="NA", dataset_file="", batchfiles_path="")
         report.train_dataset.encoded_data = enc_data_train
         report.test_dataset.encoded_data = enc_data_test
 


### PR DESCRIPTION
Keep separate 'path' and 'filenames' for element dataset: this allows element datasets to be imported from the dataset.yaml file when the dataset is moved. This fix is necessary for new Galaxy tools on the NAR branch (merged in already). Note that since this is an update to import, the version number would need to be increased. 