### PR TITLE
Bugfix: being able to read in previously exported element datasets

### DIFF
--- a/immuneML/IO/dataset_import/DataImport.py
+++ b/immuneML/IO/dataset_import/DataImport.py
@@ -2,7 +2,6 @@
 
 import abc
 import logging
-import os
 from dataclasses import fields
 from multiprocessing import Pool
 from pathlib import Path
@@ -16,7 +15,7 @@ from immuneML.data_model.AIRRSequenceSet import AIRRSequenceSet, AminoAcidXEncod
 from immuneML.data_model.SequenceSet import Repertoire, build_dynamic_airr_sequence_set_dataclass
 from immuneML.data_model.bnp_util import bnp_write_to_file, write_yaml, read_yaml
 from immuneML.data_model.datasets.Dataset import Dataset
-from immuneML.data_model.datasets.ElementDataset import SequenceDataset, ReceptorDataset
+from immuneML.data_model.datasets.ElementDataset import SequenceDataset, ReceptorDataset, ElementDataset
 from immuneML.data_model.datasets.RepertoireDataset import RepertoireDataset
 from immuneML.util.ImportHelper import ImportHelper
 from immuneML.util.ParameterValidator import ParameterValidator
@@ -31,7 +30,8 @@ class DataImport(metaclass=abc.ABCMeta):
 
     def import_dataset(self) -> Dataset:
 
-        if self.params.dataset_file is not None and self.params.dataset_file.is_file():
+        if self.params.dataset_file is not None:
+            assert self.params.dataset_file.is_file(), f"DataImport: dataset_file was specified but not found: {self.params.dataset_file}"
             dataset = self.import_dataset_from_yaml()
         else:
             if self.params.is_repertoire is None and self.params.metadata_file is not None:
@@ -98,31 +98,32 @@ class DataImport(metaclass=abc.ABCMeta):
                                  dataset_file=dataset_filename)
 
     def import_element_dataset(self, dataset_class: Type, filter_func=None):
-        filenames = ImportHelper.get_sequence_filenames(self.params.path, self.dataset_name)
-        final_df = None
+        if self.params.dataset_file is not None and self.params.dataset_file.is_file():
+            filenames = [Path(read_yaml(self.params.dataset_file)["filename"])]
+            assert filenames[0].is_file(), f"DataImport: filename {filenames[0]} specified in dataset file was not found."
+        else:
+            filenames = ImportHelper.get_sequence_filenames(self.params.path, self.dataset_name)
 
-        for filename in filenames:
-            df = self.load_sequence_dataframe(filename)
-            if filter_func:
-                df = filter_func(df)
-            final_df = pd.concat([final_df, df])
+        final_data_dict = self._construct_element_dataset_data_dict(filenames, filter_func)
 
-        final_data_dict = final_df.to_dict(orient='list')
+        bnp_dc, type_dict = build_dynamic_airr_sequence_set_dataclass(final_data_dict)
+        filename = self._write_element_dataset_tsv_file(final_data_dict, bnp_dc)
 
-        dc, types = build_dynamic_airr_sequence_set_dataclass(final_data_dict)
-        filename, dataset_file, metadata = self._prepare_values_for_element_dataset(final_data_dict, dc, types)
+        possible_labels = {key: list(set(final_data_dict[key])) for key in type_dict.keys()}
+        logging.info(f"All possible labels for dataset '{self.dataset_name}' are: {list(possible_labels.keys())}")
 
-        potential_labels = {key: list(set(final_data_dict[key])) for key in types.keys()}
         if self.params.label_columns:
             label_variants = self.params.label_columns + [ImportHelper.get_standardized_name(label_name) for label_name
                                                           in self.params.label_columns]
-            potential_labels = {key: value for key, value in potential_labels.items() if key in label_variants}
+            possible_labels = {key: value for key, value in possible_labels.items() if key in label_variants}
 
-        labels = {**metadata['labels'], **potential_labels} \
-            if 'labels' in metadata and isinstance(metadata['labels'], dict) else potential_labels
+        dataset_filename = self._write_element_dataset_metadata_file(dataset_class, filename, type_dict, possible_labels)
+        metadata = read_yaml(dataset_filename)
 
-        return dataset_class(name=self.dataset_name, bnp_dataclass=dc, dataset_file=dataset_file,
-                             dynamic_fields=types, filename=filename, labels=labels)
+        logging.info(f"Displayed labels for dataset '{self.dataset_name}' are: {list(metadata['labels'].keys())}")
+
+        return dataset_class(name=self.dataset_name, bnp_dataclass=bnp_dc, dataset_file=dataset_filename,
+                             dynamic_fields=type_dict, filename=filename, labels=metadata['labels'])
 
     def import_sequence_dataset(self) -> SequenceDataset:
         return self.import_element_dataset(SequenceDataset)
@@ -158,20 +159,39 @@ class DataImport(metaclass=abc.ABCMeta):
 
         return dataset_filename, metadata
 
-    def _prepare_values_for_element_dataset(self, final_data_dict, dc, types) -> Tuple[Path, Path, dict]:
+    def _construct_element_dataset_data_dict(self, filenames, filter_func) -> dict:
+        final_df = None
+
+        for filename in filenames:
+            df = self.load_sequence_dataframe(filename)
+            if filter_func:
+                df = filter_func(df)
+            final_df = pd.concat([final_df, df])
+
+        return final_df.to_dict(orient='list')
+
+    def _write_element_dataset_tsv_file(self, final_data_dict, bnp_dc) -> Path:
         PathBuilder.build(self.params.result_path)
 
-        data = dc(**final_data_dict)
-        bnp_write_to_file(self.params.result_path / f'{self.dataset_name}.tsv', data)
+        data = bnp_dc(**final_data_dict)
+        data_filename = self.params.result_path / f'{self.dataset_name}.tsv'
+        bnp_write_to_file(data_filename, data)
 
+        return data_filename
+
+    def _write_element_dataset_metadata_file(self, dataset_class, filename, type_dict, possible_labels):
         dataset_filename = self.params.result_path / f"{self.dataset_name}.yaml"
-        metadata = {'type_dict_dynamic_fields': {key: AIRRSequenceSet.TYPE_TO_STR[val] for key, val in types.items()}}
-        if self.params.dataset_file:
-            dataset_file_content = read_yaml(self.params.dataset_file)
-            metadata = {**dataset_file_content, **metadata}
-        write_yaml(dataset_filename, metadata)
 
-        return self.params.result_path / f'{self.dataset_name}.tsv', dataset_filename, metadata
+        if self.params.dataset_file:
+            metadata = read_yaml(self.params.dataset_file)
+        else:
+            metadata = ElementDataset.create_metadata_dict(dataset_class=dataset_class.__name__,
+                                                           filename=filename,
+                                                           type_dict=type_dict,
+                                                           name=self.dataset_name,
+                                                           labels=possible_labels)
+        write_yaml(dataset_filename, metadata)
+        return dataset_filename
 
     def load_repertoire_object(self, metadata_row: pd.Series) -> Repertoire:
         try:
@@ -246,6 +266,7 @@ class DataImport(metaclass=abc.ABCMeta):
         str_cols = [f.name for f in fields(AIRRSequenceSet)
                     if f.type in [str, AminoAcidEncoding, AminoAcidXEncoding, DNANEncoding] and f.name in df.columns]
 
+        # todo: this line throws pandas warning: 2024-11-13 17:53:10,121 WARNING: Setting an item of incompatible dtype is deprecated and will raise in a future error of pandas. Value '['' '' '' ... '' '' '']' has dtype incompatible with float64, please explicitly cast to a compatible dtype first.
         df.loc[:, str_cols] = df.loc[:, str_cols].astype(str).replace('nan', '').replace('-1.0', '')
 
         encoded_cols = [f for f, t in AIRRSequenceSet.get_field_type_dict().items()

--- a/immuneML/IO/dataset_import/DataImport.py
+++ b/immuneML/IO/dataset_import/DataImport.py
@@ -274,7 +274,7 @@ class DataImport(metaclass=abc.ABCMeta):
 
         df.loc[:, encoded_cols] = df.loc[:, encoded_cols].apply(lambda x: x.str.upper())
 
-        invalid_cols = df.columns[~df.applymap(type).nunique().eq(1)]
+        invalid_cols = df.columns[~df.map(type).nunique().eq(1)]
         df[invalid_cols] = df[invalid_cols].astype(str)
 
         int_cols = [f.name for f in fields(AIRRSequenceSet) if f.type == int and f.name in df.columns]

--- a/immuneML/data_model/AIRRSequenceSet.py
+++ b/immuneML/data_model/AIRRSequenceSet.py
@@ -17,11 +17,11 @@ class AIRRSequenceSet:
     sequence: DNANEncoding = ''
     quality: str = ''
     sequence_aa: AminoAcidXEncoding = ''
-    rev_comp: str = 'False'
-    productive: str = 'False'
-    vj_in_frame: str = 'False'
-    stop_codon: str = 'False'
-    complete_vdj: str = 'False'
+    rev_comp: str = ''
+    productive: str = ''
+    vj_in_frame: str = ''
+    stop_codon: str = ''
+    complete_vdj: str = ''
     locus: str = ''
     locus_species: str = ''
     v_call: str = ''
@@ -154,8 +154,8 @@ class AIRRSequenceSet:
     p5d2_length: int = None
     p3d2_length: int = None
     p5j_length: int = None
-    v_frameshift: str = 'False'
-    j_frameshift: str = 'False'
+    v_frameshift: str = ''
+    j_frameshift: str = ''
     d_frame: int = None
     d2_frame: int = None
     consensus_count: int = None

--- a/immuneML/data_model/datasets/ElementDataset.py
+++ b/immuneML/data_model/datasets/ElementDataset.py
@@ -37,19 +37,20 @@ class ElementDataset(Dataset, ABC):
             self.dynamic_fields = {key: AIRRSequenceSet.STR_TO_TYPE[val]
                                    for key, val in metadata['type_dict_dynamic_fields'].items()}
         if self.bnp_dataclass is None and self.dynamic_fields is not None:
-            self.bnp_dataclass = extend_dataclass_with_dynamic_fields(AIRRSequenceSet, list(self.dynamic_fields.items()))
+            self.bnp_dataclass = extend_dataclass_with_dynamic_fields(AIRRSequenceSet,
+                                                                      list(self.dynamic_fields.items()))
         if self.identifier is None:
             self.identifier = uuid4().hex
 
     @classmethod
     def create_metadata_dict(cls, dataset_class, filename, type_dict, name, labels, identifier=None):
-         return {"type_dict_dynamic_fields": {key: AIRRSequenceSet.TYPE_TO_STR[val] for key, val in type_dict.items()},
-                 "identifier": identifier if identifier is not None else uuid4().hex,
-                 "dataset_type": dataset_class if type(dataset_class) == str else dataset_class.__name__,
-                 "filename": filename,
-                 "name": name,
-                 "labels": labels,
-                 "timestamp": str(datetime.now())}
+        return {"type_dict_dynamic_fields": {key: AIRRSequenceSet.TYPE_TO_STR[val] for key, val in type_dict.items()},
+                "identifier": identifier if identifier is not None else uuid4().hex,
+                "dataset_type": dataset_class if isinstance(dataset_class, str) else dataset_class.__name__,
+                "filename": filename,
+                "name": name,
+                "labels": labels,
+                "timestamp": str(datetime.now())}
 
     @property
     def buffer_type(self):
@@ -115,7 +116,8 @@ class SequenceDataset(ElementDataset):
         write_yaml(metadata_filename, dataset_metadata)
 
         return SequenceDataset(filename=filename, name=name, labels=labels, dynamic_fields=type_dict,
-                               dataset_file=metadata_filename, bnp_dataclass=bnp_dc, identifier=dataset_metadata["identifier"])
+                               dataset_file=metadata_filename, bnp_dataclass=bnp_dc,
+                               identifier=dataset_metadata["identifier"])
 
     def get_metadata(self, field_names: list, return_df: bool = False):
         """Returns a dict or an equivalent pandas DataFrame with metadata information from Receptor objects for

--- a/immuneML/dsl/import_parsers/ImportParser.py
+++ b/immuneML/dsl/import_parsers/ImportParser.py
@@ -61,6 +61,7 @@ class ImportParser:
 
         try:
             dataset = import_cls(params, key).import_dataset()
+            assert dataset.get_example_count() > 0, "ImportParser: something went wrong when importing the data, final example count is 0"
             ImportParser.log_dataset_info(dataset)
         except KeyError as key_error:
             raise KeyError(f"{key_error}\n\nAn error occurred during parsing of dataset {key}. "

--- a/immuneML/encodings/onehot/OneHotEncoder.py
+++ b/immuneML/encodings/onehot/OneHotEncoder.py
@@ -122,8 +122,10 @@ class OneHotEncoder(DatasetEncoder):
         if self.sequence_type == SequenceType.NUCLEOTIDE and self.distance_to_seq_middle is not None:  # todo check this / explain in docs
             self.distance_to_seq_middle = self.distance_to_seq_middle * 3
 
-        self.onehot_dimensions = self.alphabet + ["start", "mid",
-                                                  "end"] if self.use_positional_info else self.alphabet  # todo test this
+        if self.use_positional_info:
+            self.onehot_dimensions = self.alphabet + ["start", "mid", "end"]
+        else:
+            self.onehot_dimensions = self.alphabet
 
     @staticmethod
     def _prepare_parameters(use_positional_info: bool, distance_to_seq_middle: int, flatten: bool, sequence_type: str,
@@ -183,9 +185,7 @@ class OneHotEncoder(DatasetEncoder):
         # Extract sequences from AIRRSequenceSet
         sequence_array = getattr(sequences, sequence_field)
 
-        sequence_alphabet = "".join(AIRRSequenceSet.get_field_type_dict()[sequence_field].get_alphabet()).replace("*",
-                                                                                                                  "").replace(
-            "X", "")
+        sequence_alphabet = "".join(EnvironmentSettings.get_sequence_alphabet(params.sequence_type))
 
         # noinspection PyTypeChecker
         encoded_sequences = np.array([

--- a/immuneML/environment/Constants.py
+++ b/immuneML/environment/Constants.py
@@ -1,6 +1,6 @@
 class Constants:
 
-    VERSION = "3.0.2"
+    VERSION = "3.0.3"
 
     # encoding constants
     FEATURE_DELIMITER = "-"

--- a/immuneML/environment/EnvironmentSettings.py
+++ b/immuneML/environment/EnvironmentSettings.py
@@ -79,6 +79,6 @@ class EnvironmentSettings:
             alphabet = list("ACGT")
             alphabet.sort()
         else:
-            raise RuntimeError("EnvironmentSettings: the sequence alphabet cannot be obtained if sequence_type was not set properly. "
-                               f"Expected AMINO_ACID or NUCLEOTIDE, but got {seq_type} instead.")
+            raise RuntimeError("EnvironmentSettings: the sequence alphabet cannot be obtained if sequence_type was "
+                               "not set properly. Expected AMINO_ACID or NUCLEOTIDE, but got {seq_type} instead.")
         return alphabet

--- a/immuneML/simulation/dataset_generation/RandomDatasetGenerator.py
+++ b/immuneML/simulation/dataset_generation/RandomDatasetGenerator.py
@@ -235,8 +235,7 @@ class RandomDatasetGenerator:
                      for i in range(sequence_count)]
 
         processed_labels, dataset_params = RandomDatasetGenerator._make_labels(labels, sequence_count)
-        dataset = SequenceDataset.build_from_objects(sequences, path, name=name,
-                                                     labels=dataset_params)
+        dataset = SequenceDataset.build_from_objects(sequences, path, name=name, labels=dataset_params)
 
         AIRRExporter.export(dataset, path)
 

--- a/immuneML/util/CompAIRRHelper.py
+++ b/immuneML/util/CompAIRRHelper.py
@@ -105,16 +105,18 @@ class CompAIRRHelper:
         for sequence in sequence_dataset.get_data():
             compairr_data["junction_aa"].append(sequence.get_sequence(sequence_type=SequenceType.AMINO_ACID))
 
-            assert sequence.identifier is not None, f"{CompAIRRHelper.__name__}: sequence identifiers must be set when exporting a sequence dataset for CompAIRR"
-            compairr_data["sequence_id"].append(sequence.identifier)
+            assert sequence.sequence_id is not None, \
+                (f"{CompAIRRHelper.__name__}: sequence identifiers must be set when exporting a sequence "
+                 f"dataset for CompAIRR.")
+            compairr_data["sequence_id"].append(sequence.sequence_id)
             compairr_data["repertoire_id"].append(repertoire_id)
 
             if not compairr_params.ignore_genes:
-                compairr_data["v_call"].append(sequence.get_attribute("v_gene"))
-                compairr_data["j_call"].append(sequence.get_attribute("j_gene"))
+                compairr_data["v_call"].append(sequence.v_call)
+                compairr_data["j_call"].append(sequence.j_call)
 
             if not compairr_params.ignore_counts:
-                compairr_data["duplicate_count"].append(sequence.get_attribute("count"))
+                compairr_data["duplicate_count"].append(sequence.duplicate_count)
 
         df = pd.DataFrame(compairr_data)
 

--- a/immuneML/util/ImportHelper.py
+++ b/immuneML/util/ImportHelper.py
@@ -273,6 +273,7 @@ class ImportHelper:
     @classmethod
     def filter_illegal_sequences(cls, df: pd.DataFrame, params: DatasetImportParams, location: str):
         try:
+            # todo this removes all sequences, because in re-imported data, productive is not 'T' and 'F' (string) but bool
             if params.import_productive:
                 df = df.loc[df.productive == 'T']
         except AttributeError as e:

--- a/immuneML/util/ImportHelper.py
+++ b/immuneML/util/ImportHelper.py
@@ -290,7 +290,7 @@ class ImportHelper:
 
         try:
             if not params.import_out_of_frame:
-                if set(df.productive).issubset({'T', 'F'}):
+                if set(df.vj_in_frame).issubset({'T', 'F'}):
                     logging.info(f"ImportHelper: import_out_of_frame is set to False. Filtering {len(df)} sequences to only keep vj_in_frame != 'F'...")
                     df = df.loc[df.vj_in_frame != 'F']
                 else:

--- a/immuneML/util/ImportHelper.py
+++ b/immuneML/util/ImportHelper.py
@@ -55,11 +55,13 @@ class ImportHelper:
                 kwargs["ascending"].append(False)
 
         elif "duplicate_count" in df.columns and len(set(df["duplicate_count"])) > 1:
-            warning += "Since umi_count was not set, attempting to select the top chain pair based on highest duplicate_count"
+            warning += ("Since umi_count was not set, attempting to select the top chain pair based on highest "
+                        "duplicate_count")
             kwargs["by"].append("duplicate_count")
             kwargs["ascending"].append(False)
         else:
-            warning += "Since duplicate_count or umi_count was not set, two random chains will be selected for each receptor."
+            warning += ("Since duplicate_count or umi_count was not set, two random chains will be selected for "
+                        "each receptor.")
         logging.warning(warning)
 
         return kwargs
@@ -73,14 +75,14 @@ class ImportHelper:
         logging.info(f"Total number of unique cell_ids (potential receptors): {len(cell_id_counts)}")
 
         if sum(cell_id_counts > 2) > 0:
-            kwargs = ImportHelper.get_receptor_filter_sort_kwargs(df, f"Found {sum(cell_id_counts > 2)} receptors with > 2 cell_ids. ")
+            kwargs = ImportHelper.get_receptor_filter_sort_kwargs(df, f"Found {sum(cell_id_counts > 2)} "
+                                                                      f"receptors with > 2 cell_ids. ")
 
             assert "locus" in df.columns, "Receptor datasets cannot be constructed if locus field is missing."
 
             df.sort_values(**kwargs, inplace=True)
             df.drop_duplicates(subset=["cell_id", "locus"], keep="first", inplace=True)
 
-            # Must recalculate cell_id_counts in case some chain had 2 identical chains (to be filtered out in next step)
             cell_id_counts = df.groupby('cell_id').size()
 
         if sum(cell_id_counts == 1) > 0:
@@ -272,9 +274,6 @@ class ImportHelper:
 
     @classmethod
     def filter_illegal_sequences(cls, df: pd.DataFrame, params: DatasetImportParams, location: str):
-        # 'productive' and 'vj_in_frame' are nullable (may contain '')
-        # For robustness, only apply filtering when these columns are correctly specified and all values are T/F
-
         try:
             if params.import_productive:
                 if set(df.productive).issubset({'T', 'F'}):
@@ -282,7 +281,9 @@ class ImportHelper:
                     df = df.loc[df.productive == 'T']
                     logging.info(f"ImportHelper: ... {len(df)} sequences left after filtering")
                 else:
-                    logging.warning(f"ImportHelper: import_productive was set to True, but unexpected values were found in the 'productive' column: {set(df.productive)} (expected 'T', 'F'). This filtering has been skipped.")
+                    logging.warning(f"ImportHelper: import_productive was set to True, but unexpected values were "
+                                    f"found in the 'productive' column: {set(df.productive)} (expected 'T', 'F'). "
+                                    f"This filtering has been skipped.")
 
         except AttributeError as e:
             logging.warning(f"An error occurred while filtering unproductive sequences while importing the "
@@ -291,10 +292,13 @@ class ImportHelper:
         try:
             if not params.import_out_of_frame:
                 if set(df.vj_in_frame).issubset({'T', 'F'}):
-                    logging.info(f"ImportHelper: import_out_of_frame is set to False. Filtering {len(df)} sequences to only keep vj_in_frame != 'F'...")
+                    logging.info(f"ImportHelper: import_out_of_frame is set to False. Filtering {len(df)} sequences "
+                                 f"to only keep vj_in_frame != 'F'...")
                     df = df.loc[df.vj_in_frame != 'F']
                 else:
-                    logging.warning(f"ImportHelper: import_out_of_frame was set to False, but unexpected values were found in the 'vj_in_frame' column: {set(df.vj_in_frame)} (expected 'T', 'F'). This filtering has been skipped.")
+                    logging.warning(f"ImportHelper: import_out_of_frame was set to False, but unexpected values were "
+                                    f"found in the 'vj_in_frame' column: {set(df.vj_in_frame)} (expected 'T', 'F'). "
+                                    f"This filtering has been skipped.")
         except AttributeError as e:
             logging.warning(f"An error occurred while filtering out-of-frame sequences while importing the "
                             f"dataset {location}. Error: {e}\n\nFiltering will be skipped.")

--- a/immuneML/workflows/instructions/train_gen_model/TrainGenModelInstruction.py
+++ b/immuneML/workflows/instructions/train_gen_model/TrainGenModelInstruction.py
@@ -161,7 +161,6 @@ class TrainGenModelInstruction(GenModelInstruction):
         metadata_yaml = SequenceDataset.create_metadata_dict(dataset_class=SequenceDataset.__name__,
                                              filename=f'combined_{self.state.name}_dataset.tsv',
                                              type_dict=type(combined_data).get_field_type_dict(all_fields=False),
-                                             identifier=uuid4().hex,
                                              name=f'combined_{self.state.name}_dataset',
                                              labels={'gen_model_name': [self.method.name, ''], "from_gen_model": [True, False]})
 

--- a/immuneML/workflows/instructions/train_gen_model/TrainGenModelInstruction.py
+++ b/immuneML/workflows/instructions/train_gen_model/TrainGenModelInstruction.py
@@ -173,8 +173,9 @@ class TrainGenModelInstruction(GenModelInstruction):
     def _get_dataclass_object_from_dataset(self, dataset: Dataset, from_gen_model_vals: np.ndarray,
                                            used_for_training_vals: np.ndarray):
         return dataset.data.add_fields(
-            {'from_gen_model': from_gen_model_vals, 'used_for_training': used_for_training_vals},
-            {'from_gen_model': bool, 'used_for_training': bool})
+            {'from_gen_model': np.where(from_gen_model_vals, 'T', 'F'),
+             'used_for_training': np.where(used_for_training_vals, 'T', 'F')},
+            {'from_gen_model': str, 'used_for_training': str})
 
     def _make_and_export_combined_dataset(self):
         if self.export_combined_dataset and isinstance(self.dataset, SequenceDataset):

--- a/test/IO/dataset_import/test_AIRRImport.py
+++ b/test/IO/dataset_import/test_AIRRImport.py
@@ -113,7 +113,7 @@ IVKNQEJ01AIS74	1	IVKNQEJ01AIS74	GGCGCAGGACTGTTGAAGCCTTCACAGACCCTGTCCCTCACCTGCACT
         dataset = AIRRImport(params, "airr_receptor_dataset").import_dataset()
 
         self.assertEqual(2, dataset.get_example_count())
-        self.assertEqual(['v_evalue', 'd_evalue', 'j_evalue', 'custom_label'], dataset.get_label_names())
+        self.assertEqual(sorted(['v_evalue', 'd_evalue', 'j_evalue', 'custom_label']), sorted(dataset.get_label_names()))
 
         for idx, receptor in enumerate(dataset.get_data()):
             self.assertTrue(receptor.heavy.sequence_aa in ['ASGVAGTFDY', 'ASGVAGNFLL'])

--- a/test/IO/dataset_import/test_ImmunoSEQRearrangementImport.py
+++ b/test/IO/dataset_import/test_ImmunoSEQRearrangementImport.py
@@ -126,8 +126,7 @@ rep2.tsv,TRB,1234a,no"""
         self.assertTrue(seqs[0].sequence_aa in ["ASSLPGTNTGELF", "SVEESYEQY"])  # OSX/windows
         self.assertEqual('T', seqs[0].vj_in_frame)
         self.assertTrue(seqs[0].v_call in ['TRBV7-9*01', 'TRBV29-1*01'])  # OSX/windows
-        print(seqs[0].j_call)
-        self.assertTrue(seqs[0].j_call in ['TRBJ2-2*01', 'TRBJ2-7*01'])  # OSX/windows
+        self.assertTrue(seqs[0].j_call in ['TRBJ2-2*01', 'TRBJ2-7'])  # OSX/windows
 
         self.assertTrue(dataset.dataset_file.is_file())
 

--- a/test/IO/dataset_import/test_ImmunoSEQRearrangementImport.py
+++ b/test/IO/dataset_import/test_ImmunoSEQRearrangementImport.py
@@ -126,6 +126,7 @@ rep2.tsv,TRB,1234a,no"""
         self.assertTrue(seqs[0].sequence_aa in ["ASSLPGTNTGELF", "SVEESYEQY"])  # OSX/windows
         self.assertEqual('T', seqs[0].vj_in_frame)
         self.assertTrue(seqs[0].v_call in ['TRBV7-9*01', 'TRBV29-1*01'])  # OSX/windows
+        print(seqs[0].j_call)
         self.assertTrue(seqs[0].j_call in ['TRBJ2-2*01', 'TRBJ2-7*01'])  # OSX/windows
 
         self.assertTrue(dataset.dataset_file.is_file())

--- a/test/api/galaxy/test_GalaxyTrainMLModel.py
+++ b/test/api/galaxy/test_GalaxyTrainMLModel.py
@@ -40,14 +40,7 @@ class TestGalaxyTrainMLModel(TestCase):
                             "model_type": "sequence",
                             "vector_size": 8,
                         }
-                    },
-                    "e2": {
-                        "Word2Vec": {
-                            "k": 3,
-                            "model_type": "sequence",
-                            "vector_size": 10,
-                        }
-                    },
+                    }
                 },
                 "ml_methods": {
                     "simpleLR": {
@@ -66,10 +59,6 @@ class TestGalaxyTrainMLModel(TestCase):
                         {
                             "encoding": "e1",
                             "ml_method": "simpleLR"
-                        },
-                        {
-                            "encoding": "e2",
-                            "ml_method": "simpleLR"
                         }
                     ],
                     "assessment": {
@@ -87,7 +76,7 @@ class TestGalaxyTrainMLModel(TestCase):
                     "strategy": "GridSearch",
                     "metrics": ["accuracy", "auc"],
                     "reports": [],
-                    "number_of_processes": 10,
+                    "number_of_processes": 1,
                     "optimization_metric": "accuracy",
                     'refit_optimal_model': False,
                 }

--- a/test/encodings/filtered_sequence_encoding/test_CompAIRRSequenceAbundanceEncoder.py
+++ b/test/encodings/filtered_sequence_encoding/test_CompAIRRSequenceAbundanceEncoder.py
@@ -23,14 +23,17 @@ class TestCompAIRRSequenceAbundanceEncoder(TestCase):
         os.environ[Constants.CACHE_TYPE] = CacheType.TEST.name
 
     def test_encode(self):
-        compairr_paths = [Path("/usr/local/bin/compairr"), Path("./compairr/src/compairr")]
+        compairr_runs = 0
 
-        for compairr_path in compairr_paths:
+        for compairr_path in EnvironmentSettings.compairr_paths:
             if compairr_path.exists():
                 self._test_encode(compairr_path)
+                compairr_runs += 1
                 break
             else:
                 print(f"test ignored for compairr path: {compairr_path}")
+
+        assert compairr_runs > 0
 
     def _build_test_dataset(self, path):
         repertoires, metadata = RepertoireBuilder.build([["GGG", "III", "LLL", "MMM"],
@@ -74,7 +77,7 @@ class TestCompAIRRSequenceAbundanceEncoder(TestCase):
             self.assertListEqual(sorted(list(contingency["negative_absent"])), sorted([1, 0, 2, 1, 0, 2, 2, 1, 0]))
 
             self.assertListEqual(sorted([round(val, 1) for val in p_values["p_values"]]), sorted([2.0, 1.0, 2.0, 0.8, 1.0, 2.0, 0.2, 0.5, 1.0]))
-            self.assertListEqual(list(relevant_sequences["sequence_aa"]), ["III"])
+            self.assertListEqual(list(relevant_sequences["cdr3_aa"]), ["III"])
 
             encoded_dataset = encoder.encode(dataset, EncoderParams(result_path=result_path, label_config=label_config))
 

--- a/test/encodings/motif_encoding/test_SimilarToPositiveSequenceEncoder.py
+++ b/test/encodings/motif_encoding/test_SimilarToPositiveSequenceEncoder.py
@@ -3,7 +3,6 @@ import shutil
 from pathlib import Path
 from unittest import TestCase
 
-
 from immuneML.caching.CacheType import CacheType
 from immuneML.data_model.datasets.ElementDataset import SequenceDataset
 from immuneML.data_model.SequenceSet import ReceptorSequence
@@ -35,7 +34,6 @@ class TestSimilarToPositiveSequenceEncoder(TestCase):
                      ReceptorSequence(sequence_aa="EEEE", sequence_id="6",
                                       metadata={"l1": "no"})]
 
-
         PathBuilder.build(path)
         dataset = SequenceDataset.build_from_objects(sequences, PathBuilder.build(path / 'data'), 'd2')
 
@@ -45,7 +43,7 @@ class TestSimilarToPositiveSequenceEncoder(TestCase):
         return dataset, lc
 
     def _get_encoder_params(self, path, lc):
-        return  EncoderParams(
+        return EncoderParams(
             result_path=path / "encoder_result/",
             label_config=lc,
             pool_size=4,
@@ -58,7 +56,8 @@ class TestSimilarToPositiveSequenceEncoder(TestCase):
         path = EnvironmentSettings.tmp_test_path / f"significant_motif_sequence_encoder_test_{path_suffix}/"
         dataset, lc = self._prepare_dataset(path)
 
-        default_params = DefaultParamsLoader.load(EnvironmentSettings.default_params_path / "encodings/", "similar_to_positive_sequence")
+        default_params = DefaultParamsLoader.load(EnvironmentSettings.default_params_path / "encodings/",
+                                                  "similar_to_positive_sequence")
 
         encoder = SimilarToPositiveSequenceEncoder.build_object(dataset, **{**default_params, **{"hamming_distance": 1,
                                                                                                  "compairr_path": compairr_path,
@@ -77,8 +76,13 @@ class TestSimilarToPositiveSequenceEncoder(TestCase):
         shutil.rmtree(path)
 
     def test_generate_with_compairr(self):
-        compairr_paths = [Path("/usr/local/bin/compairr"), Path("./compairr/src/compairr")]
+        compairr_paths = EnvironmentSettings.compairr_paths
+        compairr_runs = 0
 
         for compairr_path in compairr_paths:
             if compairr_path.exists():
                 self.test_generate(str(compairr_path))
+                compairr_runs += 1
+                break
+
+        assert compairr_runs > 0

--- a/test/integration_tests/test_dataset_export_html_output.py
+++ b/test/integration_tests/test_dataset_export_html_output.py
@@ -116,7 +116,8 @@ class TestDatasetExportHTMLOutput(TestCase):
                     }
                 }
             },
-            "instructions": {"instr1": {"type": "DatasetExport", "export_formats": ["AIRR"], "datasets": ["sequencedataset"]}},
+            "instructions": {"instr1": {"type": "DatasetExport", "export_formats": ["AIRR"],
+                                        "datasets": ["sequencedataset"]}},
             "output": {"format": "HTML"}
         }
 


### PR DESCRIPTION
- In DataImport.import_dataset, a proper 'complete' dataset_metadata file is now created
- slight reorganisation in DataImport, split into smaller methods for readability
- critical fix in filter_illegal_sequences: do not filter if 'productive' and 'vj_in_frame' are incorrectly specified or some values are set to null. better to import all data with a warning than to silently remove it all